### PR TITLE
Fix 'completion-nvim' integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,15 @@ _G.MUtils= {}
 vim.g.completion_confirm_key = ""
 
 MUtils.completion_confirm=function()
-  if vim.fn.pumvisible() ~= 0  then
-    if vim.fn.complete_info()["selected"] ~= -1 then
+  if vim.fn.pumvisible() == 0 then
+    return npairs.check_break_line_char()
+  else
+    if vim.fn.complete_info()["selected"] == -1 then
+      return npairs.esc("<c-e><CR>")
+    else
       require'completion'.confirmCompletion()
       return npairs.esc("<c-y>")
-    else
-      vim.fn.nvim_select_popupmenu_item(0 , false , false ,{})
-      require'completion'.confirmCompletion()
-      return npairs.esc("<c-n><c-y>")
     end
-  else
-    return npairs.check_break_line_char()
   end
 end
 


### PR DESCRIPTION
Based on
	- https://github.com/nvim-lua/completion-nvim/blob/master/lua/completion.lua#L260
	- https://github.com/nvim-lua/completion-nvim/blob/master/autoload/completion.vim#L3

I've changed closing key sequence, removed a few commands, and shifted things a bit to make code a bit more readable.