### PR TITLE
fix: nvim_select_popupmenu_item

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ MUtils.completion_confirm=function()
       require'completion'.confirmCompletion()
       return npairs.esc("<c-y>")
     else
-      vim.fn.nvim_select_popupmenu_item(0 , false , false ,{})
+      vim.api.nvim_select_popupmenu_item(0 , false , false ,{})
       require'completion'.confirmCompletion()
       return npairs.esc("<c-n><c-y>")
     end


### PR DESCRIPTION
nvim_select_popupmenu_item is no longer a vim.fn function