### PR TITLE
Fix configuration for nvim-compe in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,10 @@ MUtils.completion_confirm=function()
   if vim.fn.pumvisible() ~= 0  then
     if vim.fn.complete_info()["selected"] ~= -1 then
       vim.fn["compe#confirm"]()
-      return npairs.esc("<c-y>")
+      return npairs.esc("")
     else
-      vim.defer_fn(function()
-        vim.fn["compe#confirm"]("<cr>")
-      end, 20)
+      vim.api.nvim_select_popupmenu_item(0, false, false, {})
+      vim.fn["compe#confirm"]()
       return npairs.esc("<c-n>")
     end
   else


### PR DESCRIPTION
Current implementation sometimes inserts extra characters.

Taken from [this](https://github.com/hrsh7th/nvim-compe/issues/103#issuecomment-771616238) reference by the author of the plugin.