### PR TITLE
Support vimwiki filetype in triple backticks

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -10,8 +10,8 @@ local function setup(opt)
     end
     local rules = {
         Rule("<!--", "-->", 'html'):with_cr(cond.none()),
-        Rule("```", "```", 'markdown'),
-        Rule("```.*$", "```", 'markdown')
+        Rule("```", "```", { 'markdown', 'vimwiki' }),
+        Rule("```.*$", "```", { 'markdown', 'vimwiki' })
             :with_move(cond.none())
             :with_del(cond.none())
             :with_pair(cond.none())


### PR DESCRIPTION
I had problems with the triple backtick support as it is only present in markdown filetypes. Using [vimwiki](https://github.com/vimwiki/vimwiki) changes the filetype to `vimwiki`. This PR adds support for that filetype as well.

Do you want me to use the test for markdown for vimwiki files as well?