### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,7 @@ remap('i' , '<CR>','v:lua.MUtils.completion_confirm()', {expr = true , noremap =
 
 ```
   
-Make sure to remove the old compe insert mode <CR> binding if you have it:
-```diff
-- vim.api.nvim_set_keymap( 'i', '<CR>', [[compe#confirm('<CR>')]], {noremap = true, expr = true, silent = true})
--- from above
-+ remap('i' , '<CR>','v:lua.MUtils.completion_confirm()', {expr = true , noremap = true})
-
-```
+Make sure to remove the old compe insert mode `<CR>` binding if you have it.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ end
 remap('i' , '<CR>','v:lua.MUtils.completion_confirm()', {expr = true , noremap = true})
 
 ```
+  
+Make sure to remove the old compe insert mode <CR> binding if you have it:
+```diff
+- vim.api.nvim_set_keymap( 'i', '<CR>', [[compe#confirm('<CR>')]], {noremap = true, expr = true, silent = true})
+-- from above
++ remap('i' , '<CR>','v:lua.MUtils.completion_confirm()', {expr = true , noremap = true})
+
+```
 </details>
 
 <details>


### PR DESCRIPTION
Ran into an issue where I couldn't get the example compe/nvim-autopairs <CR> conflict fix to work. Turned out I just forgot to remove my old binding.

This  was a stupid issue I had but I thought it'd be nice to mention it in the readme that the user can't just copy paste the example into their config and expect it to work