### PR TITLE
Add endwise rule for Ruby

### DIFF
--- a/lua/nvim-autopairs/rules/endwise-ruby.lua
+++ b/lua/nvim-autopairs/rules/endwise-ruby.lua
@@ -1,0 +1,17 @@
+local endwise = require('nvim-autopairs.ts-rule').endwise
+
+local rules = {
+    endwise('%sdo$',              'end', 'ruby', nil),
+    endwise('%sdo%s|.*|$',        'end', 'ruby', nil),
+    endwise('begin$',             'end', 'ruby', nil),
+    endwise('def%s.+$',           'end', 'ruby', nil),
+    endwise('module%s.+$',        'end', 'ruby', nil),
+    endwise('class%s.+$',         'end', 'ruby', nil),
+    endwise('[%s=]%sif%s.+$',     'end', 'ruby', nil),
+    endwise('[%s=]%sunless%s.+$', 'end', 'ruby', nil),
+    endwise('[%s=]%scase%s.+$',   'end', 'ruby', nil),
+    endwise('[%s=]%swhile%s.+$',  'end', 'ruby', nil),
+    endwise('[%s=]%suntil%s.+$',  'end', 'ruby', nil),
+}
+
+return rules


### PR DESCRIPTION
I wrote some endwise rules for Ruby. It's not perfect and it's just based on my daily usage, but I think this one can be a good start.

There's one case I cannot manage to do though. If things like `if condition` is at the beginning of a line, it won't have endwise because it will conflict with inline `if condition`. I have to choose one. I appreciate if you guys have any advice on this.