### PR TITLE
Map Enter if no completion items is selected

### DIFF
--- a/lua/nvim-autopairs/completion/compe.lua
+++ b/lua/nvim-autopairs/completion/compe.lua
@@ -35,12 +35,8 @@ _G.MPairs.completion_done = function()
 end
 
 _G.MPairs.completion_confirm = function()
-    if vim.fn.pumvisible() ~= 0 then
-        if vim.fn.complete_info()['selected'] ~= -1 then
-            return vim.fn['compe#confirm'](npairs.esc('<cr>'))
-        else
-            return npairs.esc('<cr>')
-        end
+    if vim.fn.pumvisible() ~= 0 and vim.fn.complete_info()['selected'] ~= -1 then
+        return vim.fn['compe#confirm'](npairs.esc('<cr>'))
     else
         return npairs.autopairs_cr()
     end


### PR DESCRIPTION
In case pumvisible is true, and there is no item selected, I think we should map <CR> to `npairs.autopairs_cr()` instead of esc, so endwise can work correctly even when completion popup is on