### PR TITLE
Handle triple backticks for pandoc and rmarkdown

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -21,8 +21,8 @@ local function setup(opt)
 
     local rules = {
         Rule("<!--", "-->", 'html'):with_cr(cond.none()),
-        Rule("```", "```", { 'markdown', 'vimwiki' }),
-        Rule("```.*$", "```", { 'markdown', 'vimwiki' })
+        Rule("```", "```", { 'markdown', 'vimwiki', 'rmarkdown', 'pandoc' }),
+        Rule("```.*$", "```", { 'markdown', 'vimwiki', 'rmarkdown', 'pandoc' })
             :only_cr()
             :use_regex(true)
         ,


### PR DESCRIPTION
Properly pair up triple backticks ``` when filetype is rmarkdown or pandoc, similar to #41.

These filetypes are defined via the https://github.com/vim-pandoc/vim-rmarkdown and https://github.com/vim-pandoc/vim-pandoc packages.

Also see #13, #14, and #30