### PR TITLE
Apply triple backticks rule to `rmd` filetypes

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -21,8 +21,8 @@ local function setup(opt)
 
     local rules = {
         Rule("<!--", "-->", 'html'):with_cr(cond.none()),
-        Rule("```", "```", { 'markdown', 'vimwiki', 'rmarkdown', 'pandoc' }),
-        Rule("```.*$", "```", { 'markdown', 'vimwiki', 'rmarkdown', 'pandoc' })
+        Rule("```", "```", { 'markdown', 'vimwiki', 'rmarkdown', 'rmd', 'pandoc' }),
+        Rule("```.*$", "```", { 'markdown', 'vimwiki', 'rmarkdown', 'rmd', 'pandoc' })
             :only_cr()
             :use_regex(true)
         ,


### PR DESCRIPTION
R Markdown filetype is recognized as `rmd` by (Neo)Vim by default and only recognized as `rmarkdown` if there's a supporting plugin. This extends rules from #119 that would apply to `rmarkdown` to `rmd` as well