### PR TITLE
Added show_ts_warning option to be able to disable the startup warning message

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -16,6 +16,7 @@ local default = {
     disable_filetype = { 'TelescopePrompt', 'spectre_panel' },
     ignored_next_char = string.gsub([[ [%w%%%'%[%"%.] ]], '%s+', ''),
     check_ts = false,
+    show_ts_warning = true,
     enable_moveright = true,
     enable_afterquote = true,
     enable_check_bracket_line = true,
@@ -51,7 +52,9 @@ M.setup = function(opt)
         if ok then
             M.config.rules = ts_rule.setup(M.config)
         else
+          if M.config.show_ts_warning then
             print('you need to install treesitter')
+          end
         end
     end
 


### PR DESCRIPTION
On my Neovim config, Treesitter is not immediately loaded which causes nvim-autopairs to display the warning message "you need to install treesitter" everytime I start up neovim.

This commit allows users to be able to disable the message if the "show_ts_warning" option is set to false.
The show_ts_warning defaults to true.