### PR TITLE
Added option to modify map_complete auto-insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ Before        Input         After
 ``` lua
 require("nvim-autopairs.completion.compe").setup({
   map_cr = true, --  map <CR> on insert mode
-  map_complete = true, -- it will auto insert `(` after select function or method item
+  map_complete = true, -- it will auto insert `(` (map_char) after select function or method item
   auto_select = false,  -- auto select first item
+  map_char = { -- modifies the function or method delimiter by filetypes
+    all = '(',
+    tex = '{'
+  }
 })
 ```
 
@@ -63,8 +67,12 @@ Make sure to remove mapping insert mode `<CR>` binding if you have it.
 -- you need setup cmp first put this after cmp.setup()
 require("nvim-autopairs.completion.cmp").setup({
   map_cr = true, --  map <CR> on insert mode
-  map_complete = true, -- it will auto insert `(` after select function or method item
-  auto_select = true -- automatically select the first item
+  map_complete = true, -- it will auto insert `(` (map_char) after select function or method item
+  auto_select = true, -- automatically select the first item
+  map_char = { -- modifies the function or method delimiter by filetypes
+    all = '(',
+    tex = '{'
+  }
 })
 ```
 

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -32,11 +32,8 @@ M.setup = function(opt)
     if map_complete then
         local method_kind = cmp.lsp.CompletionItemKind.Method
         local function_kind = cmp.lsp.CompletionItemKind.Function
-        local filetype = vim.fn.expand("%:e")
-        if map_char[filetype] == nil then
-            filetype = "all"
-        end
-        local char = map_char[filetype]
+        local filetype = vim.bo.filetype
+        local char = map_char[filetype] or map_char["all"]
         cmp_setup.event = {
             on_confirm_done = function(entry)
                 local line = utils.text_get_current_line(0)

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -4,9 +4,16 @@ local cmp = require('cmp')
 
 local M = {}
 M.setup = function(opt)
-    opt = opt or { map_cr = true, map_complete = true, auto_select = true }
+    opt = opt or { map_cr = true, map_complete = true, auto_select = true, map_char = {all = '('} }
+    if not opt.map_char then
+        opt.map_char = {all = '('}
+    end
+    if opt.map_char["all"] == nil then
+        opt.map_char["all"] = '('
+    end
     local map_cr = opt.map_cr
     local map_complete = opt.map_complete
+    local map_char = opt.map_char
     local cmp_setup = {}
     if map_cr then
         cmp_setup.mapping = {
@@ -25,13 +32,18 @@ M.setup = function(opt)
     if map_complete then
         local method_kind = cmp.lsp.CompletionItemKind.Method
         local function_kind = cmp.lsp.CompletionItemKind.Function
+        local filetype = vim.fn.expand("%:e")
+        if map_char[filetype] == nil then
+            filetype = "all"
+        end
+        local char = map_char[filetype]
         cmp_setup.event = {
             on_confirm_done = function(entry)
                 local line = utils.text_get_current_line(0)
                 local _, col = utils.get_cursor()
                 local prev_char, next_char = utils.text_cusor_line(line, col, 1, 1, false)
                 local item = entry:get_completion_item()
-                if prev_char ~= '(' and next_char ~= '(' then
+                if prev_char ~= char and next_char ~= char then
                     if item.kind == method_kind or item.kind == function_kind then
                         -- check insert text have ( from snippet
                         if
@@ -44,7 +56,7 @@ M.setup = function(opt)
                         then
                             return
                         end
-                        vim.api.nvim_feedkeys('(', '', true)
+                        vim.api.nvim_feedkeys(char, '', true)
                     end
                 end
             end,

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -5,12 +5,7 @@ local cmp = require('cmp')
 local M = {}
 M.setup = function(opt)
     opt = opt or { map_cr = true, map_complete = true, auto_select = true, map_char = {all = '('} }
-    if not opt.map_char then
-        opt.map_char = {all = '('}
-    end
-    if opt.map_char["all"] == nil then
-        opt.map_char["all"] = '('
-    end
+    if not opt.map_char then opt.map_char = {} end
     local map_cr = opt.map_cr
     local map_complete = opt.map_complete
     local map_char = opt.map_char
@@ -32,14 +27,17 @@ M.setup = function(opt)
     if map_complete then
         local method_kind = cmp.lsp.CompletionItemKind.Method
         local function_kind = cmp.lsp.CompletionItemKind.Function
-        local filetype = vim.bo.filetype
-        local char = map_char[filetype] or map_char["all"]
         cmp_setup.event = {
             on_confirm_done = function(entry)
                 local line = utils.text_get_current_line(0)
                 local _, col = utils.get_cursor()
                 local prev_char, next_char = utils.text_cusor_line(line, col, 1, 1, false)
                 local item = entry:get_completion_item()
+
+                local filetype = vim.bo.filetype
+                local char = map_char[filetype] or map_char["all"] or '('
+                if char == '' then return end
+
                 if prev_char ~= char and next_char ~= char then
                     if item.kind == method_kind or item.kind == function_kind then
                         -- check insert text have ( from snippet

--- a/lua/nvim-autopairs/completion/compe.lua
+++ b/lua/nvim-autopairs/completion/compe.lua
@@ -5,11 +5,20 @@ local utils = require('nvim-autopairs.utils')
 local method_kind = nil
 local function_kind = nil
 
+local options = {}
+
 _G.MPairs.completion_done = function()
     local line = utils.text_get_current_line(0)
     local _, col = utils.get_cursor()
     local prev_char, next_char = utils.text_cusor_line(line, col, 1, 1, false)
-    if prev_char ~= '(' and next_char ~= '(' then
+
+    local filetype = vim.fn.expand("%:e")
+    if options.map_char[filetype] == nil then
+        filetype = "all"
+    end
+    local char = options.map_char[filetype]
+
+    if prev_char ~= char and next_char ~= char then
         if method_kind == nil then
             method_kind = require('vim.lsp.protocol').CompletionItemKind[2]
             function_kind = require('vim.lsp.protocol').CompletionItemKind[3]
@@ -28,14 +37,21 @@ _G.MPairs.completion_done = function()
             then
                 return
             end
-            vim.api.nvim_feedkeys('(', 'i', true)
+            vim.api.nvim_feedkeys(char, 'i', true)
         end
     end
 end
 
 local M = {}
 M.setup = function(opt)
-    opt = opt or { map_cr = true, map_complete = true, auto_select = false  }
+    opt = opt or { map_cr = true, map_complete = true, auto_select = false, map_char = {all = '('}}
+    if not opt.map_char then
+        opt.map_char = {all = '('}
+    end
+    if opt.map_char["all"] == nil then
+        opt.map_char["all"] = '('
+    end
+    options = opt
     local map_cr = opt.map_cr
     local map_complete = opt.map_complete
     vim.g.completion_confirm_key = ''

--- a/lua/nvim-autopairs/completion/compe.lua
+++ b/lua/nvim-autopairs/completion/compe.lua
@@ -13,7 +13,8 @@ _G.MPairs.completion_done = function()
     local prev_char, next_char = utils.text_cusor_line(line, col, 1, 1, false)
 
     local filetype = vim.bo.filetype
-    local char = options.map_char[filetype] or options.map_char["all"]
+    local char = options.map_char[filetype] or options.map_char["all"] or '('
+    if char == '' then return end
 
     if prev_char ~= char and next_char ~= char then
         if method_kind == nil then
@@ -42,12 +43,7 @@ end
 local M = {}
 M.setup = function(opt)
     opt = opt or { map_cr = true, map_complete = true, auto_select = false, map_char = {all = '('}}
-    if not opt.map_char then
-        opt.map_char = {all = '('}
-    end
-    if opt.map_char["all"] == nil then
-        opt.map_char["all"] = '('
-    end
+    if not opt.map_char then opt.map_char = {} end
     options = opt
     local map_cr = opt.map_cr
     local map_complete = opt.map_complete

--- a/lua/nvim-autopairs/completion/compe.lua
+++ b/lua/nvim-autopairs/completion/compe.lua
@@ -12,11 +12,8 @@ _G.MPairs.completion_done = function()
     local _, col = utils.get_cursor()
     local prev_char, next_char = utils.text_cusor_line(line, col, 1, 1, false)
 
-    local filetype = vim.fn.expand("%:e")
-    if options.map_char[filetype] == nil then
-        filetype = "all"
-    end
-    local char = options.map_char[filetype]
+    local filetype = vim.bo.filetype
+    local char = options.map_char[filetype] or options.map_char["all"]
 
     if prev_char ~= char and next_char ~= char then
         if method_kind == nil then


### PR DESCRIPTION
Fix #124

This allows to change the auto-insertion character after a function/method is auto-completed, based on filetypes:

```lua
require("nvim-autopairs.completion.compe").setup({
  map_cr = true, --  map <CR> on insert mode
  map_complete = true, -- it will auto insert `(` (map_char) after select function or method item
  map_char = {
      tex = "{",
      js = "[", -- This is incorrect, but you can change it
  },
})
```