### PR TITLE
Add option to allow setup nvim-cmp confirm behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ require("nvim-autopairs.completion.cmp").setup({
   map_cr = true, --  map <CR> on insert mode
   map_complete = true, -- it will auto insert `(` (map_char) after select function or method item
   auto_select = true, -- automatically select the first item
+  insert = false, -- use insert confirm behavior instead of replace
   map_char = { -- modifies the function or method delimiter by filetypes
     all = '(',
     tex = '{'

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -8,16 +8,20 @@ M.setup = function(opt)
         map_cr = true,
         map_complete = true,
         auto_select = true,
+        insert = false,
         map_char = { all = '(', tex = '' },
     }, opt)
     local map_cr = opt.map_cr
     local map_complete = opt.map_complete
     local map_char = opt.map_char
+    local behavior = opt.insert
+        and cmp.ConfirmBehavior.Insert
+        or cmp.ConfirmBehavior.Replace
     local cmp_setup = {}
     if map_cr then
         cmp_setup.mapping = {
             ['<CR>'] = cmp.mapping.confirm({
-                behavior = cmp.ConfirmBehavior.Replace,
+                behavior = behavior,
                 select = opt.auto_select,
             }),
         }


### PR DESCRIPTION
This allows to change the [confirm behavior of nvim-cmp](https://github.com/hrsh7th/nvim-cmp/blob/main/README.md#cmpconfirm-select--boolean-behavior--cmpconfirmbehaviorinsertreplace-) of the confirm function of nvim-cmp.

By default, Replace is used, if `insert = true` is set, this will use the Insert behavior : 

    require("nvim-autopairs.completion.cmp").setup{
      map_cr = true,
      map_complete = true,
      auto_select = true,
      insert = true,
    }
