### PR TITLE
Initialize table when opt is nil

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -4,6 +4,7 @@ local cmp = require('cmp')
 
 local M = {}
 M.setup = function(opt)
+    opt = opt or {}
     opt = vim.tbl_deep_extend('force', {
         map_cr = true,
         map_complete = true,


### PR DESCRIPTION
This code causes an error when `opt` is `nil`, that is when setup like `require("nvim-autopairs.completion.cmp").setup()`.
This pull request fixes this by initializing to an empty table when `opt` is `nil`.

https://github.com/windwp/nvim-autopairs/blob/9d76310855e739f6002d1753aa29bf2fe808e287/lua/nvim-autopairs/completion/cmp.lua#L7-L12