### PR TITLE
doc: a small change in coq_nvim config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ MUtils.CR = function()
     if vim.fn.complete_info({ 'selected' }).selected ~= -1 then
       return npairs.esc('<c-y>')
     else
-      -- you can change <c-g><c-g> to <c-e> if you don't use other i_CTRL-X modes
-      return npairs.esc('<c-g><c-g>') .. npairs.autopairs_cr()
+      return npairs.esc('<c-e>') .. npairs.autopairs_cr()
     end
   else
     return npairs.autopairs_cr()


### PR DESCRIPTION
When no item in the popup menu is selected, the intended behavior of `<CR>` should be cancelling the completion and triggering auto pairs CR, so it is fine to use `<c-e>` to close the popup menu.