### PR TITLE
doc: Add example to toggle autopairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ require('nvim-autopairs').setup({
 })
 ```
 
+### Toggle autopairs on/off
+
+Define function in `path/to` file on RTP as:
+
+```lua
+M.toggle_autopairs = function()
+  local ok, autopairs = pcall(require, "nvim-autopairs")
+  if ok then
+    if autopairs.state.disabled then
+      autopairs.enable()
+      print("autopairs on")
+    else
+      autopairs.disable()
+      print("autopairs off")
+    end
+  else
+    print("autopairs not available")
+  end
+end
+...
+return M
+
+```
+
+Use following command in your key mapping definition to a certain key
+combination sequence.
+```lua
+'<cmd>lua require("path.to").toggle_autopairs()<CR>'
+```
 
 #### Mapping `<CR>`
 ```


### PR DESCRIPTION
Although useful, under some certain edit situation, a user may wish to
turn on/off autopairs.  This example demonstrate how to enable such.

This is taken from doom-nvim PR I made.