### PR TITLE
Fix an issue where clearing a namespace fails when using fast-wrap at the first line

### DIFF
--- a/lua/nvim-autopairs/fastwrap.lua
+++ b/lua/nvim-autopairs/fastwrap.lua
@@ -83,7 +83,7 @@ M.show = function(line)
                     M.move_bracket(line, pos.col, end_pair, pos.char)
                 end
             end
-            vim.api.nvim_buf_clear_namespace(0, M.ns_fast_wrap, row - 1, row + 1)
+            vim.api.nvim_buf_clear_namespace(0, M.ns_fast_wrap, row, row + 1)
             vim.cmd('startinsert')
         end, 10)
         return


### PR DESCRIPTION
The following error occurs and marks such as `$` are still displayed:

```
Error executing vim.schedule lua callback: ...om/windwp/nvim-autopairs/lua/nvim-autopairs/fastwrap.lua:86: Line number outside range
```

## Reproduction

1. Save the following code as `minimal.vim` on the root of this repository

```vim
set runtimepath+=.

lua << EOF
require('nvim-autopairs').setup({
    fast_wrap = {}
})
EOF
```

2. `nvim -u minimal.vim`
3. Enter Insert-mode and type `(` and `<M-e>`