### PR TITLE
feat: add option to disable when recording or executing a macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ require('nvim-autopairs').setup{}
 
 ``` lua
 local disable_filetype = { "TelescopePrompt" }
+local disable_in_macro = false  -- disable when recording or executing a macro
 local ignored_next_char = string.gsub([[ [%w%%%'%[%"%.] ]],"%s+", "")
 local enable_moveright = true
 local enable_afterquote = true  -- add bracket pairs after quote

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -15,6 +15,7 @@ local default = {
     map_bs = true,
     map_c_w = false,
     disable_filetype = { 'TelescopePrompt', 'spectre_panel' },
+    disable_in_macro = false,
     ignored_next_char = string.gsub([[ [%w%%%'%[%"%.] ]], '%s+', ''),
     check_ts = false,
     enable_moveright = true,
@@ -131,6 +132,9 @@ local function is_disable()
         return true
     end
     if vim.bo.modifiable == false then
+        return true
+    end
+    if M.config.disable_in_macro and (vim.fn.reg_recording() ~= '' or vim.fn.reg_executing() ~= '') then
         return true
     end
 


### PR DESCRIPTION
As `nvim-autopairs`'s behavior is context-dependent, using `nvim-autopairs` in a macro can cause the macro to behave differently in different places. Therefore, I'd like an option to disable `nvim-autopairs` when recording or executing a macro so that the macros I recorded are context-independent.