### PR TITLE
Added julia to the triple quote rule

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -28,7 +28,7 @@ local function setup(opt)
         Rule("```.*$", "```", { 'markdown', 'vimwiki', 'rmarkdown', 'rmd', 'pandoc' })
             :only_cr()
             :use_regex(true),
-        Rule('"""', '"""', { 'python', 'elixir' }),
+        Rule('"""', '"""', { 'python', 'elixir', 'julia' }),
         basic("'", "'", '-rust')
             :with_pair(cond.not_before_regex_check("%w")),
         basic("'", "'", 'rust')


### PR DESCRIPTION
Added as, like python, Julia also uses triple quotes for docstrings