### PR TITLE
feat(cmp): wrap lisp functions instead of appending paran

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ check readme.md on nvim-cmp repo.
 local cmp_autopairs = require('nvim-autopairs.completion.cmp')
 local cmp = require('cmp')
 cmp.event:on( 'confirm_done', cmp_autopairs.on_confirm_done({  map_char = { tex = '' } }))
+-- To add a lisp filetype (wrap my-function), FYI: Hardcoded = { "clojure", "clojurescript", "fennel", "janet" }
+cmp_autopairs.lisp[#cmp_autopairs.lisp+1] = "racket"
 ```
 </details>
 <details>

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -3,49 +3,57 @@ local utils = require('nvim-autopairs.utils')
 local cmp = require('cmp')
 
 local M = {}
+
 M.setup = function()
-    vim.notify(
-        '[nvim-autopairs] function nvim-autopairs.completion.cmp setup is deprecated.'
-    )
+    vim.notify('[nvim-autopairs] function nvim-autopairs.completion.cmp setup is deprecated.')
     vim.notify('[nvim-autopairs] remove this function and use require("cmp").setup to add <cr> mapping.')
 end
 
+M.lisp = { "clojure", "clojurescript", "fennel", "janet" }
+
+local ignore_append = function(char, kinds, next_char, prev_char, item)
+    if (char == '')
+        or (prev_char == char and next_char == char)
+        or (not utils.is_in_table(kinds, item.kind))
+        or (item.textEdit and item.textEdit.newText and item.textEdit.newText:match "[%(%[]")
+        or (item.insertText and item.insertText:match "[%(%[]")
+    then
+        return true
+    end
+end
+
 M.on_confirm_done = function(opt)
-    opt = opt or {}
     opt = vim.tbl_deep_extend('force', {
         map_char = { tex = '' },
-        kind = {
+        kinds = {
             cmp.lsp.CompletionItemKind.Method,
             cmp.lsp.CompletionItemKind.Function,
         },
-    }, opt)
-    local map_char = opt.map_char
+    }, opt or {})
+
     return function(entry)
         local line = utils.text_get_current_line(0)
         local _, col = utils.get_cursor()
         local prev_char, next_char = utils.text_cusor_line(line, col, 1, 1, false)
         local item = entry:get_completion_item()
 
-        local char = map_char[vim.bo.filetype] or '('
+        local char = opt.map_char[vim.bo.filetype] or '('
         if char == '' then
             return
         end
 
-        if prev_char ~= char and next_char ~= char then
-            if utils.is_in_table(opt.kind, item.kind) then
-                -- check insert text have ( from snippet
-                if
-                    (
-                        item.textEdit
-                        and item.textEdit.newText
-                        and item.textEdit.newText:match('[%(%[]')
-                    )
-                    or (item.insertText and item.insertText:match('[%(%[]'))
-                then
-                    return
-                end
-                vim.api.nvim_feedkeys(char, 'i', true)
-            end
+        if ignore_append(char, opt.kinds, next_char, prev_char, item)  then
+            return
+        end
+
+        if utils.is_in_table(M.lisp, vim.bo.filetype) then
+            local length = #item.label
+            utils.feed(utils.key.left, length)
+            utils.feed("(")
+            utils.feed(utils.key.right, length)
+            utils.feed("<Space>")
+        else
+            vim.api.nvim_feedkeys(char, 'i', true)
         end
     end
 end

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -48,6 +48,10 @@ M.on_confirm_done = function(opt)
 
         if utils.is_in_table(M.lisp, vim.bo.filetype) then
             local length = #item.label
+            if utils.text_sub_char(line, col - length, 1) == "(" then
+              utils.feed("<Space>")
+              return
+            end
             utils.feed(utils.key.left, length)
             utils.feed("(")
             utils.feed(utils.key.right, length)


### PR DESCRIPTION
### Purpose

closes #175

- [x] make lisp filetype configurable? 
  - opt 1: through appending/redfining 'nvim-autopairs.completion.cmp'.lisp?
  - opt 2: pass extra lisp filetypes in on confirm function?