### PR TITLE
Add endwise support for inline anonymous functions in Elixir

### DIFF
--- a/lua/nvim-autopairs/rules/endwise-elixir.lua
+++ b/lua/nvim-autopairs/rules/endwise-elixir.lua
@@ -1,8 +1,9 @@
 local endwise = require('nvim-autopairs.ts-rule').endwise
 
 local rules = {
-  endwise('%sdo$', 'end', 'elixir', nil),
-  endwise('fn$',   'end', 'elixir', nil),
+  endwise('%sdo$',   'end', 'elixir', nil),
+  endwise('fn$',     'end', 'elixir', nil),
+  endwise('fn.*->$', 'end', 'elixir', nil),
 }
 
 return rules


### PR DESCRIPTION
Appends `end` in the following cases:
```elixir
fn (foo) ->
  ...
end
```
https://hexdocs.pm/elixir/1.12/Enum.html#chunk_while/4-examples

/cc @micke 