### PR TITLE
fix: use 0 instead of nil for current buffer

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -345,6 +345,7 @@ local autopairs_delete = function(bufnr, key)
     if is_disable() then
         return utils.esc(key)
     end
+    bufnr = bufnr or 0
     local line = utils.text_get_current_line(bufnr)
     local _, col = utils.get_cursor()
     local rules = M.get_buf_rules(bufnr)


### PR DESCRIPTION
Ref <https://github.com/neovim/neovim/pull/16745>