### PR TITLE
fix: do not trigger `InsertLeave` when `<CR>`

### DIFF
--- a/lua/nvim-autopairs/rule.lua
+++ b/lua/nvim-autopairs/rule.lua
@@ -110,7 +110,7 @@ function Rule:get_map_cr(opts)
     if self.map_cr_func then
         return self.map_cr_func(opts)
     end
-    return '<c-g>u<cr><c-o>O'
+    return '<c-g>u<cr><c-c>O'
 end
 
 


### PR DESCRIPTION
Current default `map_cr` implementation utilizes `<C-o>` to execute `O` in normal mode and then return to insert mode. However, according to [`:h InsertLeave`](https://neovim.io/doc/user/autocmd.html#InsertLeave), `<C-o>` will trigger the `InsertLeave` autocmd, which introduces various other side effects. In my case:

- `InsertLeave` triggers auto save, then `BufWrite`;
- `BufWrite` triggers lsp formatting and editorconfig.

An insert mode `<CR>` operation should not trigger such things. Therefore I propose to replace `<C-o>O` with `<C-c>O`, which could achieve the same results without triggering `InsertLeave` autocmd.