### PR TITLE
Fixed double parentheses bug when using nvim-cmp

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -56,7 +56,7 @@ M.on_confirm_done = function(opt)
             utils.feed("(")
             utils.feed(utils.key.right, length)
             utils.feed("<Space>")
-        else
+        elseif evt.commit_character ~= "(" then
             vim.api.nvim_feedkeys(char, 'i', true)
         end
     end

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -42,7 +42,7 @@ M.on_confirm_done = function(opt)
             return
         end
 
-        if ignore_append(char, opt.kinds, next_char, prev_char, item)  then
+        if ignore_append(char, opt.kinds, next_char, prev_char, item) or evt.commit_character == char  then
             return
         end
 
@@ -56,7 +56,7 @@ M.on_confirm_done = function(opt)
             utils.feed("(")
             utils.feed(utils.key.right, length)
             utils.feed("<Space>")
-        elseif evt.commit_character ~= "(" then
+        else
             vim.api.nvim_feedkeys(char, 'i', true)
         end
     end


### PR DESCRIPTION
When commiting a function completion using the '(' character in cmp you
end up with two pairs of parentheses instead of one.

nvim-cmp has just merged a PR (https://github.com/hrsh7th/nvim-cmp/pull/782) that sends the `commit_character` via the
`confirm_done` event.

This commit uses this information to avoid adding a second pair of
parentheses when the user has alredy typed one.