### PR TITLE
Prevent auto-pairing on completion, when completion item is a Snippet

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -17,6 +17,7 @@ local ignore_append = function(char, kinds, next_char, prev_char, item)
         or (not utils.is_in_table(kinds, item.kind))
         or (item.textEdit and item.textEdit.newText and item.textEdit.newText:match "[%(%[]")
         or (item.insertText and item.insertText:match "[%(%[]")
+        or (item.insertTextFormat and item.insertTextFormat == cmp.lsp.InsertTextFormat.Snippet)
     then
         return true
     end

--- a/lua/nvim-autopairs/completion/compe.lua
+++ b/lua/nvim-autopairs/completion/compe.lua
@@ -32,6 +32,7 @@ _G.MPairs.completion_done = function()
                     and completion_item.textEdit.newText:match('[%(%[]')
                 )
                 or (completion_item.insertText and completion_item.insertText:match('[%(%[]'))
+                or (completion_item.insertTextFormat and completion_item.insertTextFormat == require('vim.lsp.protocol').InsertTextFormat[2])
             then
                 return
             end


### PR DESCRIPTION
I discovered a potential issue when enabling auto-pairs on completion while using elixir-ls.  Elixir-ls has two different ways to auto-complete functions, because it has both regular method calls (e.g, `String.length()`) as well as method references (e.g. `&String.length/1`).

What I found was, elixir-ls is trying to be smart about which way you are using a function when providing a completion.  In doing so, it always provides an `insertText` with an `insertTextFormat` set to `Snippet`.  It basically does the following:

When completing `String.length()`, it auto-adds the parentheses already, and places the cursor between them (essentially doing what auto-pairs already does).  The pattern looks something like `String.length($1)$0`.

When completing `&String.length/1`, it completes to that exact string, as well as selecting the arity (the `/1`) and places the user in Select mode, presumably so that the user can change the arity if they wish, or tab to leave it unchanged.  The pattern looks something like `&String.length${1:/1}$0`.

Before this change, auto-pairs deletes the arity in the latter example (since its selected), and adds parentheses.

I think it makes sense to assume that, if a language server is providing a snippet format back for completion, that there is a good chance you want to skip trying to auto-pair.

I was able to test this using the nvim-cmp plugin (what I use), but made a guess on how to fix it also in the compe plugin.