### PR TITLE
Remove deprecated setup() function.

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -4,11 +4,6 @@ local cmp = require('cmp')
 
 local M = {}
 
-M.setup = function()
-    vim.notify('[nvim-autopairs] function nvim-autopairs.completion.cmp setup is deprecated.')
-    vim.notify('[nvim-autopairs] remove this function and use require("cmp").setup to add <cr> mapping.')
-end
-
 M.lisp = { "clojure", "clojurescript", "fennel", "janet" }
 
 local ignore_append = function(char, kinds, next_char, prev_char, item)


### PR DESCRIPTION
The existence of this causes sumneko_lua to think that the call to `cmp.setup()` requires 0 arguments.

Additionally, it allows for going to the correct definition, instead of the one defined in `nvim-autopairs.completion.cmp`.