### PR TITLE
Invalid buffer when using autopairs with autosave plugins

### DIFF
--- a/lua/nvim-autopairs/utils.lua
+++ b/lua/nvim-autopairs/utils.lua
@@ -112,6 +112,7 @@ M.get_cursor = function(bufnr)
     return row - 1, col
 end
 M.text_get_line = function(bufnr, lnum)
+    if not api.nvim_buf_is_loaded(bufnr) then return end
     return api.nvim_buf_get_lines(bufnr, lnum, lnum + 1, false)[1] or ''
 end
 


### PR DESCRIPTION
Fixes issue seen in #173 where I'd get invalid buffer id if I used this with an auto-save plugin.