### PR TITLE
fix: use vim.treesitter.query instead of deprecated nvim-treesitter.t…

### DIFF
--- a/lua/nvim-autopairs/ts-conds.lua
+++ b/lua/nvim-autopairs/ts-conds.lua
@@ -3,6 +3,7 @@ local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
 local log = require('nvim-autopairs._log')
 local parsers = require'nvim-treesitter.parsers'
 local utils = require('nvim-autopairs.utils')
+local ts_query = vim.treesitter.query
 
 local conds = {}
 
@@ -19,7 +20,7 @@ conds.is_endwise_node = function(nodes)
         parsers.get_parser():parse()
         local target = ts_utils.get_node_at_cursor()
         if target ~= nil and utils.is_in_table(nodes, target:type()) then
-            local text = ts_utils.get_node_text(target) or {""}
+            local text = ts_query.get_node_text(target) or {""}
             local last = text[#text]:match(opts.rule.end_pair)
             -- check last character is match with end_pair
             if last == nil then
@@ -31,9 +32,9 @@ conds.is_endwise_node = function(nodes)
                 local begin_target,_, end_target = target:range()
                 local begin_parent,_, end_parent = target:parent():range()
                 -- log.debug(target:range())
-                -- log.debug(ts_utils.get_node_text(target))
+                -- log.debug(ts_query.get_node_text(target))
                 -- log.debug(target:parent():range())
-                -- log.debug(ts_utils.get_node_text(target:parent()))
+                -- log.debug(ts_query.get_node_text(target:parent()))
                 if
                     (
                         begin_target ~= begin_parent

--- a/lua/nvim-autopairs/ts-utils.lua
+++ b/lua/nvim-autopairs/ts-utils.lua
@@ -1,11 +1,10 @@
-
-local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
+local ts_query = vim.treesitter.query
 local M = {}
 
 function M.get_tag_name(node)
   local tag_name = nil
   if node ~=nil then
-    tag_name = ts_utils.get_node_text(node)
+    tag_name = ts_query.get_node_text(node)
   end
   return tag_name
 end

--- a/tests/test_utils.lua
+++ b/tests/test_utils.lua
@@ -1,7 +1,7 @@
 local utils = require('nvim-autopairs.utils')
-local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
 local log = require('nvim-autopairs._log')
 local api = vim.api
+local ts_query = vim.treesitter.query
 
 local helpers = {}
 
@@ -164,7 +164,7 @@ _G.Test_withfile = function(test_data, cb)
 end
 
 _G.dump_node = function(node)
-    local text = ts_utils.get_node_text(node)
+    local text = ts_query.get_node_text(node)
     for _, txt in pairs(text) do
         print(txt)
     end
@@ -173,7 +173,7 @@ end
 _G.dump_node_text = function(target)
     for node in target:iter_children() do
         local node_type = node:type()
-        local text = ts_utils.get_node_text(node)
+        local text = ts_query.get_node_text(node)
         log.debug('type:' .. node_type .. ' ')
         log.debug(text)
     end


### PR DESCRIPTION
…s_query

Using vim.treesitter.query instead of deprecated nvim-treesitter.ts_query in https://github.com/nvim-treesitter/nvim-treesitter/commit/c3848e713a8272e524a7eabe9eb0897cf2d6932e

Fixes:
![image](https://user-images.githubusercontent.com/17691791/163973692-91625214-14fd-4d05-b388-2d30f89b3c8f.png)
