### PR TITLE
Use replace_endpair when expanding with endwise

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -559,7 +559,7 @@ M.autopairs_cr = function(bufnr)
                 check_endwise_ts = true,
                 rule = rule,
                 bufnr = bufnr,
-                col = col + 1,
+                col = col,
                 line = line,
                 prev_char = prev_char,
                 next_char = next_char,
@@ -583,19 +583,13 @@ M.autopairs_cr = function(bufnr)
                         .. '<cr><esc>====O'
                 )
             end
+
+            cond_opt.check_endwise_ts = false
+
             if
                 utils.compare(rule.start_pair, prev_char, rule.is_regex)
                 and utils.compare(rule.end_pair, next_char, rule.is_regex)
-                and rule:can_cr({
-                    ts_node = M.state.ts_node,
-                    check_endwise_ts = false,
-                    bufnr = bufnr,
-                    rule = rule,
-                    col = col,
-                    prev_char = prev_char,
-                    next_char = next_char,
-                    line = line,
-                })
+                and rule:can_cr(cond_opt)
             then
                 log.debug('do_cr')
                 return utils.esc(rule:get_map_cr({rule = rule, line = line, color = col, bufnr = bufnr}))

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -553,26 +553,32 @@ M.autopairs_cr = function(bufnr)
                 #rule.end_pair,
                 rule.is_regex
             )
+
+            local cond_opt = {
+                ts_node = M.state.ts_node,
+                check_endwise_ts = true,
+                rule = rule,
+                bufnr = bufnr,
+                col = col + 1,
+                line = line,
+                prev_char = prev_char,
+                next_char = next_char,
+            }
+
+            local end_pair = rule:get_end_pair(cond_opt)
+            local end_pair_length = rule:get_end_pair_length(end_pair)
+
             -- log.debug('prev_char' .. rule.start_pair)
             -- log.debug('prev_char' .. prev_char)
             -- log.debug('next_char' .. next_char)
             if
                 rule.is_endwise
                 and utils.compare(rule.start_pair, prev_char, rule.is_regex)
-                and rule:can_cr({
-                    ts_node = M.state.ts_node,
-                    check_endwise_ts = true,
-                    bufnr = bufnr,
-                    rule = rule,
-                    col = col,
-                    prev_char = prev_char,
-                    next_char = next_char,
-                    line = line,
-                })
+                and rule:can_cr(cond_opt)
             then
                 return utils.esc(
-                    rule.end_pair
-                        .. utils.repeat_key(utils.key.join_left, #rule.end_pair)
+                    end_pair
+                        .. utils.repeat_key(utils.key.join_left, end_pair_length)
                         -- FIXME do i need to re indent twice #118
                         .. '<cr><esc>====O'
                 )

--- a/tests/nvim-autopairs_spec.lua
+++ b/tests/nvim-autopairs_spec.lua
@@ -596,6 +596,42 @@ local data = {
         before = [[   | aaa]],
         after = [[   "ab| aaa]]
     },
+    {
+        setup_func = function()
+            npairs.clear_rules()
+            npairs.add_rule(Rule("{", "}"):end_wise())
+        end,
+        filetype = 'javascript',
+        name = 'custom endwise rule',
+        key = [[<cr>]],
+        before = [[function () {| ]],
+        after = {
+            [[function () {]],
+            [[|]],
+            [[}]],
+        },
+    },
+    {
+        setup_func = function()
+            npairs.clear_rules()
+            npairs.add_rule(
+                Rule("{", "")
+                    :replace_endpair(function ()
+                        return "}"
+                    end)
+                    :end_wise()
+            )
+        end,
+        filetype = 'javascript',
+        name = 'custom endwise rule with custom end_pair',
+        key = [[<cr>]],
+        before = [[function () {| ]],
+        after = {
+            [[function () {]],
+            [[|]],
+            [[}]],
+        },
+    },
 }
 
 local run_data = _G.Test_filter(data)


### PR DESCRIPTION
This PR fixes an issue when expanding an endwise rule, the rules' custom end pair (using `replace_endpair`) was not used - but the rules' original end pair was.

Originally, I was trying to implement a rule that works like [vim-closer](https://github.com/rstacruz/vim-closer). It tries to close all of the opened pairs in that line when pressing `<CR>`.

### Example usage

The following gist implements a rule that acts like vim-closer, described above: 

https://gist.github.com/yardnsm/3818a56526d3d56343b00a03aa2b0269

Input:

```javascript
(function () { |
```

After pressing `<CR>`:

```javascript
(function () {
    |
})
```