### PR TITLE
Proposal: rewrite `cmp.on_confirm_done`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ cmp.event:on(
 You can customize the kind of completion to add `(` or any character.
 
 ```lua
+local handlers = require('nvim-autopairs.completion.handlers')
+
 cmp.event:on(
   'confirm_done',
   cmp_autopairs.on_confirm_done({
@@ -78,27 +80,32 @@ cmp.event:on(
             cmp.lsp.CompletionItemKind.Function,
             cmp.lsp.CompletionItemKind.Method,
           },
-          handler = cmp_autopairs.handler
+          handler = handlers["*"]
         }
       },
       lua = {
         ["("] = {
-          kind = { cmp.lsp.CompletionItemKind.Function },
+          kind = {
+            cmp.lsp.CompletionItemKind.Function,
+            cmp.lsp.CompletionItemKind.Method
+          },
           ---@param char string
-          ---@param item entry completion item
+          ---@param item item completion
           ---@param rules Array<Rule>
           ---@param bufnr buffer number
           handler = function(char, item, rules, bufnr)
-            -- You handler function
+            -- You handler function. Inpect with print(vim.inspect{char, item, rules, bufnr})
           end
         }
       },
-      -- Disable for python filetype
-      python = false
+      -- Disable for tex
+      tex = false
     }
   })
 )
 ```
+
+Don't use `nil` to disable a filetype. If a filetype is `nil` then `*` is used as fallback.
 
 </details>
 <details>

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cmp.event:on(
           ---@param rules Array<Rule>
           ---@param bufnr buffer number
           handler = function(char, item, rules, bufnr)
-            -- You handler function. Inpect with print(vim.inspect{char, item, rules, bufnr})
+            -- Your handler function. Inpect with print(vim.inspect{char, item, rules, bufnr})
           end
         }
       },

--- a/README.md
+++ b/README.md
@@ -58,13 +58,48 @@ Check readme.md on nvim-cmp repo.
 -- If you want insert `(` after select function or method item
 local cmp_autopairs = require('nvim-autopairs.completion.cmp')
 local cmp = require('cmp')
-cmp.event:on( 'confirm_done', cmp_autopairs.on_confirm_done({  map_char = { tex = '' } }))
-
-
--- add a lisp filetype (wrap my-function), FYI: Hardcoded = { "clojure", "clojurescript", "fennel", "janet" }
-cmp_autopairs.lisp[#cmp_autopairs.lisp+1] = "racket"
-
+cmp.event:on(
+  'confirm_done',
+  cmp_autopairs.on_confirm_done()
+)
 ```
+
+You can customize the kind of completion to add `(` or any character.
+
+```lua
+cmp.event:on(
+  'confirm_done',
+  cmp_autopairs.on_confirm_done({
+    filetypes = {
+      -- "*" is a alias to all filetypes
+      ["*"] = {
+        ["("] = {
+          kind = {
+            cmp.lsp.CompletionItemKind.Function,
+            cmp.lsp.CompletionItemKind.Method,
+          },
+          handler = cmp_autopairs.handler
+        }
+      },
+      lua = {
+        ["("] = {
+          kind = { cmp.lsp.CompletionItemKind.Function },
+          ---@param char string
+          ---@param item entry completion item
+          ---@param rules Array<Rule>
+          ---@param bufnr buffer number
+          handler = function(char, item, rules, bufnr)
+            -- You handler function
+          end
+        }
+      },
+      -- Disable for python filetype
+      python = false
+    }
+  })
+)
+```
+
 </details>
 <details>
 <summary><b>coq_nvim</b></summary>

--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ cmp.event:on(
           },
           ---@param char string
           ---@param item item completion
-          ---@param rules Array<Rule>
           ---@param bufnr buffer number
-          handler = function(char, item, rules, bufnr)
-            -- Your handler function. Inpect with print(vim.inspect{char, item, rules, bufnr})
+          handler = function(char, item, bufnr)
+            -- Your handler function. Inpect with print(vim.inspect{char, item, bufnr})
           end
         }
       },

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -55,7 +55,7 @@ M.filetypes = {
     -- Alias to all filetypes
     ["*"] = {
         ["("] = {
-            kind = { cmp.lsp.CompletionItemKind.Function, cmp.lsp.CompletionItemKind.Method, cmp.lsp.CompletionItemKind.Variable },
+            kind = { cmp.lsp.CompletionItemKind.Function, cmp.lsp.CompletionItemKind.Method },
             handler = M.handler
         }
     }
@@ -72,23 +72,27 @@ M.on_confirm_done = function(opt)
         local filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
         local item = entry:get_completion_item()
 
+        if not opt.filetypes["*"] and not opt.filetypes[filetype] then
+          return
+        end
+
         local filetype_opt = opt.filetypes[filetype] or opt.filetypes["*"]
 
         local rules = vim.tbl_filter(function(rule)
-            local char_opt = filetype_opt[rule.key_map]
+            local char_options = filetype_opt[rule.key_map]
 
-            if not char_opt or not char_opt.kind then
+            if not char_options or not char_options.kind then
                 return false
             end
 
-            local valid_rule = not vim.tbl_isempty(char_opt) and vim.tbl_contains(char_opt.kind, item.kind)
+            local is_valid_rule = not vim.tbl_isempty(char_options) and vim.tbl_contains(char_options.kind, item.kind)
 
             if rule.filetypes then
-                return vim.tbl_contains(rule.filetypes, filetype) and valid_rule
+                return vim.tbl_contains(rule.filetypes, filetype) and is_valid_rule
             elseif rule.not_filetypes then
-                return not vim.tbl_contains(rule.not_filetypes, filetype) and valid_rule
+                return not vim.tbl_contains(rule.not_filetypes, filetype) and is_valid_rule
             else
-                return valid_rule
+                return is_valid_rule
             end
         end, autopairs.get_buf_rules(bufnr))
 

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -57,20 +57,16 @@ M.on_confirm_done = function(opts)
           return
         end
 
-        -- If filetype option is false
         if opts.filetypes[filetype] == false then
           return
         end
 
+        -- If filetype is nil then use *
         local completion_options = opts.filetypes[filetype] or opts.filetypes["*"]
-
-        local rules = vim.tbl_filter(function(rule)
-            return completion_options[rule.key_map]
-        end, autopairs.get_buf_rules(bufnr))
 
         for char, value in pairs(completion_options) do
             if vim.tbl_contains(value.kind, item.kind) then
-                value.handler(char, item, rules, bufnr)
+                value.handler(char, item, bufnr)
             end
         end
     end

--- a/lua/nvim-autopairs/completion/handlers.lua
+++ b/lua/nvim-autopairs/completion/handlers.lua
@@ -1,13 +1,12 @@
-local autopairs = require('nvim-autopairs')
+-- local autopairs = require('nvim-autopairs')
 local utils = require('nvim-autopairs.utils')
 
 local M = {}
 
 ---@param char string
 ---@param item table
----@param rules table
 ---@param bufnr number
-M["*"] = function(char, item, rules, bufnr)
+M["*"] = function(char, item, bufnr)
     local line = utils.text_get_current_line(bufnr)
     local _, col = utils.get_cursor()
     local char_before, char_after = utils.text_cusor_line(line, col, 1, 1, false)
@@ -20,39 +19,11 @@ M["*"] = function(char, item, rules, bufnr)
         return
     end
 
-    local new_text = ''
-    local add_char = 1
-
-    for _, rule in pairs(rules) do
-        if rule.start_pair then
-            local prev_char, next_char = utils.text_cusor_line(
-                new_text,
-                col + add_char,
-                #rule.start_pair,
-                #rule.end_pair,
-                rule.is_regex
-            )
-            local cond_opt = {
-                ts_node = autopairs.state.ts_node,
-                text = new_text,
-                rule = rule,
-                bufnr = bufnr,
-                col = col + 1,
-                char = char,
-                line = line,
-                prev_char = prev_char,
-                next_char = next_char,
-            }
-            if rule.key_map and rule:can_pair(cond_opt) then
-                vim.api.nvim_feedkeys(rule.key_map, "i", true)
-            end
-        end
-    end
+    vim.api.nvim_feedkeys(char, "i", true)
 end
 
---- Handler with "clojure", "clojurescript", "fennel", "janet
---- @note this handler not apply rules for lisp filetypes
-M.lisp = function (char, item, rules, bufnr)
+---Handler with "clojure", "clojurescript", "fennel", "janet
+M.lisp = function (char, item, bufnr)
   local line = utils.text_get_current_line(bufnr)
   local _, col = utils.get_cursor()
   local char_before, char_after = utils.text_cusor_line(line, col, 1, 1, false)

--- a/lua/nvim-autopairs/completion/handlers.lua
+++ b/lua/nvim-autopairs/completion/handlers.lua
@@ -1,0 +1,78 @@
+local autopairs = require('nvim-autopairs')
+local utils = require('nvim-autopairs.utils')
+
+local M = {}
+
+---@param char string
+---@param item table
+---@param rules table
+---@param bufnr number
+M["*"] = function(char, item, rules, bufnr)
+    local line = utils.text_get_current_line(bufnr)
+    local _, col = utils.get_cursor()
+    local char_before, char_after = utils.text_cusor_line(line, col, 1, 1, false)
+
+    if char == '' or char_before == char or char_after == char
+        or (item.data and item.data.funcParensDisabled)
+        or (item.textEdit and item.textEdit.newText and item.textEdit.newText:match "[%(%[%$]")
+        or (item.insertText and item.insertText:match "[%(%[%$]")
+    then
+        return
+    end
+
+    local new_text = ''
+    local add_char = 1
+
+    for _, rule in pairs(rules) do
+        if rule.start_pair then
+            local prev_char, next_char = utils.text_cusor_line(
+                new_text,
+                col + add_char,
+                #rule.start_pair,
+                #rule.end_pair,
+                rule.is_regex
+            )
+            local cond_opt = {
+                ts_node = autopairs.state.ts_node,
+                text = new_text,
+                rule = rule,
+                bufnr = bufnr,
+                col = col + 1,
+                char = char,
+                line = line,
+                prev_char = prev_char,
+                next_char = next_char,
+            }
+            if rule.key_map and rule:can_pair(cond_opt) then
+                vim.api.nvim_feedkeys(rule.key_map, "i", true)
+            end
+        end
+    end
+end
+
+--- Handler with "clojure", "clojurescript", "fennel", "janet
+--- @note this handler not apply rules for lisp filetypes
+M.lisp = function (char, item, rules, bufnr)
+  local line = utils.text_get_current_line(bufnr)
+  local _, col = utils.get_cursor()
+  local char_before, char_after = utils.text_cusor_line(line, col, 1, 1, false)
+  local length = #item.label
+
+  if char == '' or char_before == char or char_after == char
+    or (item.data and item.data.funcParensDisabled)
+    or (item.textEdit and item.textEdit.newText and item.textEdit.newText:match "[%(%[%$]")
+    or (item.insertText and item.insertText:match "[%(%[%$]") then
+    return
+  end
+
+  if utils.text_sub_char(line, col - length, 1) == "(" then
+      utils.feed("<Space>")
+      return
+  end
+  utils.feed(utils.key.left, length)
+  utils.feed(char)
+  utils.feed(utils.key.right, length)
+  utils.feed("<Space>")
+end
+
+return M


### PR DESCRIPTION
This PR is a proposal to rewrite `on_confirm_done`

This PR adds some defaults:

- Each filetype has a setting
- A check based on the `kind` of autocomplete
- A `handler` function on `on_confirm_done`

The idea is that the user handles each filetype.

### Proposal

```lua
M.filetypes = {
    -- Alias to all filetype
    ["*"] = {
        ["("] = {
            kind = {
              cmp.lsp.CompletionItemKind.Function,
              cmp.lsp.CompletionItemKind.Method,
            },
            handler = function(char, item, bufnr) end
        }
    }
}
```

`kind` determines which `cmp` return types from autocomplete are valid for adding `(`