### PR TITLE
Use `commit_character` from nvim-cmp event to avoid adding double parenthesis

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -48,6 +48,7 @@ M.on_confirm_done = function(opts)
 
     return function(evt)
         local entry = evt.entry
+        local commit_character = evt.commit_character
         local bufnr = vim.api.nvim_get_current_buf()
         local filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
         local item = entry:get_completion_item()
@@ -66,7 +67,7 @@ M.on_confirm_done = function(opts)
 
         for char, value in pairs(completion_options) do
             if vim.tbl_contains(value.kind, item.kind) then
-                value.handler(char, item, bufnr)
+                value.handler(char, item, bufnr, commit_character)
             end
         end
     end

--- a/lua/nvim-autopairs/completion/handlers.lua
+++ b/lua/nvim-autopairs/completion/handlers.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@param char string
 ---@param item table
 ---@param bufnr number
-M["*"] = function(char, item, bufnr)
+M["*"] = function(char, item, bufnr, commit_character)
     local line = utils.text_get_current_line(bufnr)
     local _, col = utils.get_cursor()
     local char_before, char_after = utils.text_cusor_line(line, col, 1, 1, false)
@@ -15,6 +15,7 @@ M["*"] = function(char, item, bufnr)
         or (item.data and item.data.funcParensDisabled)
         or (item.textEdit and item.textEdit.newText and item.textEdit.newText:match "[%(%[%$]")
         or (item.insertText and item.insertText:match "[%(%[%$]")
+        or char == commit_character
     then
         return
     end

--- a/lua/nvim-autopairs/completion/handlers.lua
+++ b/lua/nvim-autopairs/completion/handlers.lua
@@ -24,7 +24,7 @@ M["*"] = function(char, item, bufnr, commit_character)
 end
 
 ---Handler with "clojure", "clojurescript", "fennel", "janet
-M.lisp = function (char, item, bufnr)
+M.lisp = function (char, item, bufnr, commit_character)
   local line = utils.text_get_current_line(bufnr)
   local _, col = utils.get_cursor()
   local char_before, char_after = utils.text_cusor_line(line, col, 1, 1, false)
@@ -33,7 +33,9 @@ M.lisp = function (char, item, bufnr)
   if char == '' or char_before == char or char_after == char
     or (item.data and item.data.funcParensDisabled)
     or (item.textEdit and item.textEdit.newText and item.textEdit.newText:match "[%(%[%$]")
-    or (item.insertText and item.insertText:match "[%(%[%$]") then
+    or (item.insertText and item.insertText:match "[%(%[%$]")
+    or char == commit_character
+  then
     return
   end
 


### PR DESCRIPTION
The `on_confirm_done` event from nvim-cmp sends us which character was used to commit the completion via the `commit_character` entry.

This PR:
* Passes the `commit_character` as the last parameter to the `*` handler.
* Modifies the `*` handler to check if `commit_character` is equal to the trigger character `char`. If they are equal it skips adding another pair.  

