### PR TITLE
python triple single quotes pair

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -37,7 +37,7 @@ local function setup(opt)
             :only_cr()
             :use_regex(true),
         Rule('"""', '"""', { 'python', 'elixir', 'julia', 'kotlin' }),
-        Rule("'''", "'''", { 'python' })
+        Rule("'''", "'''", { 'python' }),
         basic("'", "'", '-rust')
             :with_pair(cond.not_before_regex("%w")),
         basic("'", "'", 'rust')

--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -37,6 +37,7 @@ local function setup(opt)
             :only_cr()
             :use_regex(true),
         Rule('"""', '"""', { 'python', 'elixir', 'julia', 'kotlin' }),
+        Rule("'''", "'''", { 'python' })
         basic("'", "'", '-rust')
             :with_pair(cond.not_before_regex("%w")),
         basic("'", "'", 'rust')


### PR DESCRIPTION
Python allows for tripple quotes to be `'''`.