### PR TITLE
Pass column and rule information to `:with_del` callback

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -363,10 +363,12 @@ local autopairs_delete = function(bufnr, key)
                 and utils.compare(rule.end_pair, next_char, rule.is_regex)
                 and rule:can_del({
                     ts_node = M.state.ts_node,
+                    rule = rule,
                     bufnr = bufnr,
                     prev_char = prev_char,
                     next_char = next_char,
                     line = line,
+                    col = col,
                 })
             then
                 local input = ''


### PR DESCRIPTION
Pass `col` and `rule` to the `:with_del` callback so it matches the other `:with_*` callbacks.