### PR TITLE
fix: reduce unexpected `end_pair_func` executions

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -233,7 +233,7 @@ M.on_attach = function(bufnr)
                 if rule.key_map == '' then
                     rule.key_map = rule.start_pair:sub(#rule.start_pair)
                 end
-                local mapping = string.format('v:lua.MPairs.autopairs_map(%d,%q)', bufnr, rule.key_map)
+                local mapping = string.format('v:lua.MPairs.autopairs_map(%d,%q)', bufnr, rule.key_map:gsub("<", "<lt>"))
                 api.nvim_buf_set_keymap(
                     bufnr,
                     'i',
@@ -262,7 +262,7 @@ M.on_attach = function(bufnr)
                     local mapping = string.format(
                         "v:lua.MPairs.autopairs_map(%d,%q)",
                         bufnr,
-                        rule.key_map
+                        rule.key_map:gsub("<", "<lt>")
                     )
                     api.nvim_buf_set_keymap(
                         bufnr,
@@ -403,8 +403,8 @@ M.autopairs_map = function(bufnr, char)
     local add_char = 1
     local rules = M.get_buf_rules(bufnr)
     for _, rule in pairs(rules) do
-        if rule.start_pair then
-            if rule.key_map and rule.key_map:match('<.*>') then
+        if rule.key_map == char then
+            if char:match('<.*>') then
                 new_text = line:sub(1, col) .. line:sub(col + 1, #line)
                 add_char = 0
             else
@@ -467,7 +467,7 @@ M.autopairs_map = function(bufnr, char)
             end
         end
     end
-    return M.autopairs_afterquote(new_text, char)
+    return M.autopairs_afterquote(new_text, utils.esc(char))
 end
 
 M.autopairs_insert = function(bufnr, char)

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -233,11 +233,7 @@ M.on_attach = function(bufnr)
                 if rule.key_map == '' then
                     rule.key_map = rule.start_pair:sub(#rule.start_pair)
                 end
-                local key = string.format('"%s"', rule.key_map)
-                if rule.key_map == '"' then
-                    key = [['"']]
-                end
-                local mapping = string.format('v:lua.MPairs.autopairs_map(%d,%s)', bufnr, key)
+                local mapping = string.format('v:lua.MPairs.autopairs_map(%d,%q)', bufnr, rule.key_map)
                 api.nvim_buf_set_keymap(
                     bufnr,
                     'i',
@@ -249,7 +245,7 @@ M.on_attach = function(bufnr)
                 local key_end = rule.key_end or rule.end_pair:sub(1, 1)
                 if #key_end >= 1 and key_end ~= rule.key_map and rule.move_cond ~= nil then
                     mapping = string.format(
-                        [[v:lua.MPairs.autopairs_map(%d, '%s')]],
+                        [[v:lua.MPairs.autopairs_map(%d, %q)]],
                         bufnr,
                         key_end
                     )
@@ -264,7 +260,7 @@ M.on_attach = function(bufnr)
             else
                 if rule.key_map ~= '' then
                     local mapping = string.format(
-                        "v:lua.MPairs.autopairs_map(%d,'%s')",
+                        "v:lua.MPairs.autopairs_map(%d,%q)",
                         bufnr,
                         rule.key_map
                     )

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -233,7 +233,11 @@ M.on_attach = function(bufnr)
                 if rule.key_map == '' then
                     rule.key_map = rule.start_pair:sub(#rule.start_pair)
                 end
-                local mapping = string.format('v:lua.MPairs.autopairs_map(%d,%q)', bufnr, rule.key_map:gsub("<", "<lt>"))
+                local mapping = string.format(
+                    "v:lua.MPairs.autopairs_map(%d,%q)",
+                    bufnr,
+                    rule.key_map:gsub("<", "<lt>")
+                )
                 api.nvim_buf_set_keymap(
                     bufnr,
                     'i',
@@ -245,7 +249,7 @@ M.on_attach = function(bufnr)
                 local key_end = rule.key_end or rule.end_pair:sub(1, 1)
                 if #key_end >= 1 and key_end ~= rule.key_map and rule.move_cond ~= nil then
                     mapping = string.format(
-                        [[v:lua.MPairs.autopairs_map(%d, %q)]],
+                        "v:lua.MPairs.autopairs_map(%d,%q)",
                         bufnr,
                         key_end
                     )

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -557,10 +557,6 @@ M.autopairs_cr = function(bufnr)
                 prev_char = prev_char,
                 next_char = next_char,
             }
-
-            local end_pair = rule:get_end_pair(cond_opt)
-            local end_pair_length = rule:get_end_pair_length(end_pair)
-
             -- log.debug('prev_char' .. rule.start_pair)
             -- log.debug('prev_char' .. prev_char)
             -- log.debug('next_char' .. next_char)
@@ -568,6 +564,8 @@ M.autopairs_cr = function(bufnr)
                 and utils.compare(rule.start_pair, prev_char, rule.is_regex)
                 and rule:can_cr(cond_opt)
             then
+                local end_pair = rule:get_end_pair(cond_opt)
+                local end_pair_length = rule:get_end_pair_length(end_pair)
                 return utils.esc(
                     end_pair
                     .. utils.repeat_key(utils.key.join_left, end_pair_length)


### PR DESCRIPTION
https://github.com/windwp/nvim-autopairs/blob/34bd374f75fb58656572f847e2bc3565b0acb34f/lua/nvim-autopairs.lua#L410
Though I've removed the line, are any cases yet expected?