### PR TITLE
Fix empty rules when bufnr is 0

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -328,7 +328,7 @@ local autopairs_delete = function(bufnr, key)
     if is_disable() then
         return utils.esc(key)
     end
-    bufnr = bufnr or 0
+    bufnr = bufnr or api.nvim_get_current_buf()
     local line = utils.text_get_current_line(bufnr)
     local _, col = utils.get_cursor()
     local rules = M.get_buf_rules(bufnr)


### PR DESCRIPTION
When using the mapping for `<BS>` in README:

```lua
MUtils.BS = function()
  if vim.fn.pumvisible() ~= 0 and vim.fn.complete_info({ 'mode' }).mode == 'eval' then
    return npairs.esc('<c-e>') .. npairs.autopairs_bs()
  else
    return npairs.autopairs_bs()
  end
end
remap('i', '<bs>', 'v:lua.MUtils.BS()', { expr = true, noremap = true })
```

no `bufnr` is passed to `autopairs_bs()` thus the default value would be `0`, and in this condition, the result of 

```lua
    local rules = M.get_buf_rules(bufnr)
```

will be an empty table.