### PR TITLE
Fix `on_confirm_done`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ cmp.event:on(
             cmp.lsp.CompletionItemKind.Method
           },
           ---@param char string
-          ---@param item item completion
-          ---@param bufnr buffer number
-          handler = function(char, item, bufnr)
-            -- Your handler function. Inpect with print(vim.inspect{char, item, bufnr})
+          ---@param item table item completion
+          ---@param bufnr number buffer number
+          ---@param rules table
+          ---@param commit_character table<string>
+          handler = function(char, item, bufnr, rules, commit_character)
+            -- Your handler function. Inpect with print(vim.inspect{char, item, bufnr, rules, commit_character})
           end
         }
       },

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -48,7 +48,7 @@ M.on_confirm_done = function(opts)
 
     return function(evt)
         local entry = evt.entry
-        local commit_character = evt.commit_character
+        local commit_character = entry:get_commit_characters()
         local bufnr = vim.api.nvim_get_current_buf()
         local filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
         local item = entry:get_completion_item()
@@ -65,9 +65,13 @@ M.on_confirm_done = function(opts)
         -- If filetype is nil then use *
         local completion_options = opts.filetypes[filetype] or opts.filetypes["*"]
 
+        local rules = vim.tbl_filter(function(rule)
+            return completion_options[rule.key_map]
+        end, autopairs.get_buf_rules(bufnr))
+
         for char, value in pairs(completion_options) do
             if vim.tbl_contains(value.kind, item.kind) then
-                value.handler(char, item, bufnr, commit_character)
+                value.handler(char, item, bufnr, rules, commit_character)
             end
         end
     end

--- a/lua/nvim-autopairs/completion/handlers.lua
+++ b/lua/nvim-autopairs/completion/handlers.lua
@@ -51,6 +51,7 @@ M["*"] = function(char, item, bufnr, rules, commit_character)
             }
             if rule.key_map and rule:can_pair(cond_opt) then
                 vim.api.nvim_feedkeys(rule.key_map, "i", true)
+                return
             end
         end
     end

--- a/lua/nvim-autopairs/completion/handlers.lua
+++ b/lua/nvim-autopairs/completion/handlers.lua
@@ -1,4 +1,4 @@
--- local autopairs = require('nvim-autopairs')
+local autopairs = require('nvim-autopairs')
 local utils = require('nvim-autopairs.utils')
 
 local M = {}
@@ -6,7 +6,9 @@ local M = {}
 ---@param char string
 ---@param item table
 ---@param bufnr number
-M["*"] = function(char, item, bufnr, commit_character)
+---@param rules table
+---@param commit_character table<string>
+M["*"] = function(char, item, bufnr, rules, commit_character)
     local line = utils.text_get_current_line(bufnr)
     local _, col = utils.get_cursor()
     local char_before, char_after = utils.text_cusor_line(line, col, 1, 1, false)
@@ -15,16 +17,47 @@ M["*"] = function(char, item, bufnr, commit_character)
         or (item.data and item.data.funcParensDisabled)
         or (item.textEdit and item.textEdit.newText and item.textEdit.newText:match "[%(%[%$]")
         or (item.insertText and item.insertText:match "[%(%[%$]")
-        or char == commit_character
+        or vim.tbl_contains(commit_character, char)
     then
         return
     end
 
-    vim.api.nvim_feedkeys(char, "i", true)
+    if vim.tbl_isempty(rules) then
+        return
+    end
+
+    local new_text = ''
+    local add_char = 1
+
+    for _, rule in pairs(rules) do
+        if rule.start_pair then
+            local prev_char, next_char = utils.text_cusor_line(
+                new_text,
+                col + add_char,
+                #rule.start_pair,
+                #rule.end_pair,
+                rule.is_regex
+            )
+            local cond_opt = {
+                ts_node = autopairs.state.ts_node,
+                text = new_text,
+                rule = rule,
+                bufnr = bufnr,
+                col = col + 1,
+                char = char,
+                line = line,
+                prev_char = prev_char,
+                next_char = next_char,
+            }
+            if rule.key_map and rule:can_pair(cond_opt) then
+                vim.api.nvim_feedkeys(rule.key_map, "i", true)
+            end
+        end
+    end
 end
 
 ---Handler with "clojure", "clojurescript", "fennel", "janet
-M.lisp = function (char, item, bufnr, commit_character)
+M.lisp = function (char, item, bufnr, _, commit_character)
   local line = utils.text_get_current_line(bufnr)
   local _, col = utils.get_cursor()
   local char_before, char_after = utils.text_cusor_line(line, col, 1, 1, false)
@@ -34,7 +67,7 @@ M.lisp = function (char, item, bufnr, commit_character)
     or (item.data and item.data.funcParensDisabled)
     or (item.textEdit and item.textEdit.newText and item.textEdit.newText:match "[%(%[%$]")
     or (item.insertText and item.insertText:match "[%(%[%$]")
-    or char == commit_character
+    or vim.tbl_contains(commit_character, char)
   then
     return
   end


### PR DESCRIPTION
During #244, the check of rules was removed. Using only `vim.api.nvim_feedkeys`.

The check must be done because it is not done in the same way as the insertion. It is done after completion, before insert `(`

**JavaScript Example**: Add after completion `()` only if not in `import_statement` or `named_imports` node.

```lua
cmp.event:on('confirm_done', cmp_autopairs.on_confirm_done())

Rule(
    '(',
    ')',
    { 'javascript', 'typescript', 'javascriptreact', 'typescriptreact' }
  ):with_pair(ts_conds.is_in_range(function(param)
    if not param then
      return false
    end
    return not vim.tbl_contains(
      { 'named_imports', 'import_statement' },
      param.type
    )
  end, function()
    local cursor = vim.api.nvim_win_get_cursor(0)
    return { cursor[1] - 1, cursor[2] }
  end)),
```


https://user-images.githubusercontent.com/16160544/193376358-e820545f-17dd-4e22-a115-967277ed8b50.mp4


#### Other Fix

Change `evt.commit_character` to `entry:get_commit_characters()` which is a table of string.

The `evt` output:

```lua
{
  entry = {
    cache = {
      entries = {
        get_completion_item = {
          commitCharacters = <1>{ ".", ",", "(" },
          data = <2>{
            entryNames = { "isNaN" },
            file = "/home/pedro/Desktop/test-filetypes/javascript.js",
            line = 1,
            offset = 2
          },
          detail = "function isNaN(number: number): boolean",
          documentation = <3>{
            kind = "markdown",
            value = "Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number).\n\n*@param* `number` — A numeric value."
          },
          kind = 3,
          label = "isNaN",
          sortText = "15",
          textEdit = <4>{
            insert = {
              ["end"] = {
                character = 1,
                line = 0
              },
              start = {
                character = 5,
                line = 0
              }
            },
            newText = "isNaN",
            replace = {
              ["end"] = {
                character = 1,
                line = 0
              },
              start = {
                character = 0,
                line = 0
              }
            }
          }
        },
        get_offset = 1,
        get_overwrite = <5>{ 1, 0 },
        ["get_view:4"] = {
          abbr = {
            bytes = 5,
            hl_group = "CmpItemAbbr",
            text = "isNaN",
            width = 5
          },
          dup = 1,
          kind = {
            bytes = 3,
            hl_group = "CmpItemKindFunction",
            text = "",
            width = 1
          },
          menu = {
            bytes = 5,
            hl_group = "CmpItemMenu",
            text = "[LSP]",
            width = 5
          }
        },
        ["get_vim_item:1"] = {
          abbr = "isNaN",
          dup = 1,
          empty = 1,
          equal = 1,
          kind = "",
          menu = "[LSP]",
          word = "isNaN"
        },
        get_word = "isNaN"
      },
      <metatable> = {
        __index = <6>{
          clear = <function 1>,
          ensure = <function 2>,
          get = <function 3>,
          key = <function 4>,
          new = <function 5>,
          set = <function 6>
        }
      }
    },
    completion_item = {
      commitCharacters = { ".", ",", "(" },
      data = {
        entryNames = { "isNaN" },
        file = "/home/pedro/Desktop/test-filetypes/javascript.js",
        line = 1,
        offset = 2
      },
      kind = 3,
      label = "isNaN",
      sortText = "15",
      textEdit = {
        insert = {
          ["end"] = {
            character = 1,
            line = 0
          },
          start = {
            character = 0,
            line = 0
          }
        },
        newText = "isNaN",
        replace = {
          ["end"] = {
            character = 1,
            line = 0
          },
          start = {
            character = 0,
            line = 0
          }
        }
      }
    },
    confirmed = true,
    context = {
      bufnr = 1,
      cache = {
        entries = {
          ["entry:get_offset:0"] = 1,
          ["entry:get_overwrite:0:1"] = <table 5>,
          ["get_offset:\\%(-\\?\\d\\+\\%(\\.\\d\\+\\)\\?\\|\\h\\%(\\w\\|á\\|Á\\|é\\|É\\|í\\|Í\\|ó\\|Ó\\|ú\\|Ú\\)*\\%(-\\%(\\w\\|á\\|Á\\|é\\|É\\|í\\|Í\\|ó\\|Ó\\|ú\\|Ú\\)*\\)*\\):i"] = 1,
          ["get_offset:\\%(-\\?\\d\\+\\%(\\.\\d\\+\\)\\?\\|\\h\\w*\\%(-\\w*\\)*\\):i"] = 1,
          ["get_offset:\\%([^/\\\\:\\*?<>'\"`\\|]\\)*:i"] = 1,
          ["get_offset:\\%([^[:alnum:][:blank:]]\\|\\w\\+\\):i"] = 1
        },
        <metatable> = {
          __index = <table 6>
        }
      },
      cursor = {
        character = 1,
        col = 2,
        line = 0,
        row = 1
      },
      cursor_after_line = "",
      cursor_before_line = "i",
      cursor_line = "i",
      filetype = "javascript",
      id = 14,
      option = {
        reason = "auto"
      },
      prev_context = {
        bufnr = 1,
        cursor = {
          character = 0,
          col = 1,
          line = 0,
          row = 1
        },
        cursor_after_line = "",
        cursor_before_line = "",
        cursor_line = "",
        filetype = "javascript",
        id = 13,
        option = {
          reason = "auto"
        },
        time = 205958644
      },
      time = 205959133,
      <metatable> = {
        __index = <7>{
          changed = <function 7>,
          clone = <function 8>,
          empty = <function 9>,
          get_offset = <function 10>,
          get_reason = <function 11>,
          new = <function 12>
        }
      }
    },
    exact = false,
    id = 390,
    match_cache = {
      entries = {
        ["i:0:0:0:0"] = {
          matches = { {
              fuzzy = false,
              index = 1,
              input_match_end = 1,
              input_match_start = 1,
              no_symbol_match = false,
              strict_ratio = 1,
              word_match_end = 1,
              word_match_start = 1
            } },
          score = 17.8
        },
        ["is:0:0:0:0"] = {
          matches = { {
              fuzzy = false,
              index = 1,
              input_match_end = 2,
              input_match_start = 1,
              no_symbol_match = false,
              strict_ratio = 1,
              word_match_end = 2,
              word_match_start = 1
            } },
          score = 21.6
        },
        ["isN:0:0:0:0"] = {
          matches = <8>{ {
              fuzzy = false,
              index = 1,
              input_match_end = 3,
              input_match_start = 1,
              no_symbol_match = false,
              strict_ratio = 1,
              word_match_end = 3,
              word_match_start = 1
            } },
          score = 25.4
        }
      },
      <metatable> = {
        __index = <table 6>
      }
    },
    matches = <table 8>,
    resolved_callbacks = { <function 13> },
    resolved_completion_item = {
      commitCharacters = <table 1>,
      data = <table 2>,
      detail = "function isNaN(number: number): boolean",
      documentation = <table 3>,
      kind = 3,
      label = "isNaN",
      sortText = "15",
      textEdit = <table 4>
    },
    resolving = true,
    score = 25.4,
    source = {
      cache = {
        entries = {},
        <metatable> = {
          __index = <table 6>
        }
      },
      complete_dedup = <function 14>,
      context = {
        bufnr = -1,
        cache = {
          entries = {},
          <metatable> = {
            __index = <table 6>
          }
        },
        cursor = {
          col = -1,
          row = -1
        },
        cursor_after_line = "",
        cursor_before_line = "isNaN",
        cursor_line = "isNaN",
        filetype = "javascript",
        id = 37,
        input = "",
        option = {},
        prev_context = {},
        time = 205960670,
        <metatable> = {
          __index = <table 7>
        }
      },
      entries = {},
      id = 9,
      incomplete = false,
      is_triggered_by_symbol = false,
      name = "nvim_lsp",
      offset = -1,
      request_offset = -1,
      revision = 3,
      source = {
        client = {
          _on_attach = <function 15>,
          attached_buffers = { true },
          cancel_request = <function 16>,
          commands = {},
          config = {
            _on_attach = <function 17>,
            autostart = true,
            capabilities = {
              callHierarchy = {
                dynamicRegistration = false
              },
              textDocument = {
                codeAction = {
                  codeActionLiteralSupport = {
                    codeActionKind = {
                      valueSet = { "", "Empty", "QuickFix", "Refactor", "RefactorExtract", "RefactorInline", "RefactorRewrite", "Source", "SourceOrganizeImports", "quickfix", "refactor", "refactor.extract", "refactor.inline", "refactor.rewrite", "source", "source.organizeImports" }
                    }
                  },
                  dataSupport = true,
                  dynamicRegistration = false,
                  isPreferredSupport = true,
                  resolveSupport = {
                    properties = { "edit" }
                  }
                },
                colorProvider = {
                  dynamicRegistration = true
                },
                completion = {
                  completionItem = {
                    commitCharactersSupport = true,
                    deprecatedSupport = true,
                    documentationFormat = { "markdown", "plaintext" },
                    insertReplaceSupport = true,
                    labelDetailsSupport = true,
                    preselectSupport = true,
                    resolveSupport = {
                      properties = { "documentation", "detail", "additionalTextEdits" }
                    },
                    snippetSupport = true,
                    tagSupport = {
                      valueSet = { 1 }
                    }
                  },
                  completionItemKind = {
                    valueSet = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 }
                  },
                  contextSupport = false,
                  dynamicRegistration = false
                },
                declaration = {
                  linkSupport = true
                },
                definition = {
                  linkSupport = true
                },
                documentHighlight = {
                  dynamicRegistration = false
                },
                documentSymbol = {
                  dynamicRegistration = false,
                  hierarchicalDocumentSymbolSupport = true,
                  symbolKind = {
                    valueSet = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 }
                  }
                },
                hover = {
                  contentFormat = { "markdown", "plaintext" },
                  dynamicRegistration = false
                },
                implementation = {
                  linkSupport = true
                },
                publishDiagnostics = {
                  relatedInformation = true,
                  tagSupport = {
                    valueSet = { 1, 2 }
                  }
                },
                references = {
                  dynamicRegistration = false
                },
                rename = {
                  dynamicRegistration = false,
                  prepareSupport = true
                },
                signatureHelp = {
                  dynamicRegistration = false,
                  signatureInformation = {
                    activeParameterSupport = true,
                    documentationFormat = { "markdown", "plaintext" },
                    parameterInformation = {
                      labelOffsetSupport = true
                    }
                  }
                },
                synchronization = {
                  didSave = true,
                  dynamicRegistration = false,
                  willSave = false,
                  willSaveWaitUntil = false
                },
                typeDefinition = {
                  linkSupport = true
                }
              },
              window = {
                showDocument = {
                  support = false
                },
                showMessage = {
                  messageActionItem = {
                    additionalPropertiesSupport = false
                  }
                },
                workDoneProgress = true
              },
              workspace = {
                applyEdit = true,
                configuration = true,
                symbol = {
                  dynamicRegistration = false,
                  hierarchicalWorkspaceSymbolSupport = true,
                  symbolKind = {
                    valueSet = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 }
                  }
                },
                workspaceEdit = {
                  resourceOperations = { "rename", "create", "delete" }
                },
                workspaceFolders = true
              }
            },
            cmd = { "typescript-language-server", "--stdio" },
            cmd_cwd = "/home/pedro/Desktop/test-filetypes",
            filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
            flags = {},
            get_language_id = <function 18>,
            handlers = <9>{},
            init_options = {
              hostInfo = "neovim",
              preferences = {
                includeInlayEnumMemberValueHints = true,
                includeInlayFunctionLikeReturnTypeHints = true,
                includeInlayFunctionParameterTypeHints = true,
                includeInlayParameterNameHints = "all",
                includeInlayParameterNameHintsWhenArgumentMatchesName = true,
                includeInlayPropertyDeclarationTypeHints = true,
                includeInlayVariableTypeHints = true,
                jsxAttributeCompletionStyle = "auto"
              }
            },
            log_level = 2,
            message_level = 2,
            name = "tsserver",
            on_attach = <function 19>,
            on_exit = <function 20>,
            on_init = <function 21>,
            root_dir = "/home/pedro/Desktop/test-filetypes",
            settings = vim.empty_dict(),
            workspace_folders = <10>{ {
                name = "/home/pedro/Desktop/test-filetypes",
                uri = "file:///home/pedro/Desktop/test-filetypes"
              } },
            <metatable> = <11>{
              __tostring = <function 22>
            }
          },
          handlers = <table 9>,
          id = 1,
          initialized = true,
          is_stopped = <function 23>,
          messages = {
            messages = {},
            name = "tsserver",
            progress = {
              ["c738f995-8a78-46fd-9051-500afcc9e13c"] = {
                done = true,
                title = "Initializing JS/TS language features…"
              }
            },
            status = {}
          },
          name = "tsserver",
          notify = <function 24>,
          offset_encoding = "utf-16",
          request = <function 25>,
          request_sync = <function 26>,
          requests = {},
          rpc = {
            is_closing = <function 27>,
            notify = <function 28>,
            request = <function 29>,
            terminate = <function 30>
          },
          server_capabilities = {
            callsProvider = true,
            codeActionProvider = {
              codeActionKinds = { "source.fixAll.ts", "source.removeUnused.ts", "source.addMissingImports.ts", "source.organizeImports.ts", "quickfix", "refactor" }
            },
            completionProvider = {
              resolveProvider = true,
              triggerCharacters = { ".", '"', "'", "/", "@", "<" }
            },
            definitionProvider = true,
            documentFormattingProvider = true,
            documentHighlightProvider = true,
            documentRangeFormattingProvider = true,
            documentSymbolProvider = true,
            executeCommandProvider = {
              commands = { "_typescript.applyWorkspaceEdit", "_typescript.applyCodeAction", "_typescript.applyRefactoring", "_typescript.organizeImports", "_typescript.applyRenameFile", "_typescript.goToSourceDefinition" }
            },
            foldingRangeProvider = true,
            hoverProvider = true,
            implementationProvider = true,
            inlayHintProvider = true,
            referencesProvider = true,
            renameProvider = true,
            semanticTokensProvider = {
              full = true,
              legend = {
                tokenModifiers = { "declaration", "static", "async", "readonly", "defaultLibrary", "local" },
                tokenTypes = { "class", "enum", "interface", "namespace", "typeParameter", "type", "parameter", "variable", "enumMember", "property", "function", "member" }
              },
              range = true
            },
            signatureHelpProvider = {
              retriggerCharacters = { ")" },
              triggerCharacters = { "(", ")", ")", ")", ")", ",", "<" }
            },
            textDocumentSync = {
              change = 2,
              openClose = true,
              save = {
                includeText = false
              },
              willSave = false,
              willSaveWaitUntil = false
            },
            typeDefinitionProvider = true,
            workspaceSymbolProvider = true
          },
          stop = <function 31>,
          supports_method = <function 32>,
          workspaceFolders = <table 10>,
          workspace_did_change_configuration = <function 33>,
          workspace_folders = <table 10>,
          <metatable> = {
            __index = <function 34>
          }
        },
        request_ids = {},
        <metatable> = {
          __index = {
            _get = <function 35>,
            _request = <function 36>,
            complete = <function 37>,
            execute = <function 38>,
            get_debug_name = <function 39>,
            get_trigger_characters = <function 40>,
            is_available = <function 41>,
            new = <function 42>,
            resolve = <function 43>
          }
        }
      },
      status = 1,
      <metatable> = {
        __index = {
          SourceStatus = {
            COMPLETED = 3,
            FETCHING = 2,
            WAITING = 1
          },
          complete = <function 44>,
          execute = <function 45>,
          get_debug_name = <function 46>,
          get_default_insert_range = <function 47>,
          get_default_replace_range = <function 48>,
          get_entries = <function 49>,
          get_entry_filter = <function 50>,
          get_fetching_time = <function 51>,
          get_keyword_length = <function 52>,
          get_keyword_pattern = <function 53>,
          get_matching_config = <function 54>,
          get_source_config = <function 55>,
          get_trigger_characters = <function 56>,
          is_available = <function 57>,
          new = <function 58>,
          reset = <function 59>,
          resolve = <function 60>
        }
      }
    },
    source_insert_range = {
      ["end"] = {
        character = 1,
        line = 0
      },
      start = {
        character = 0,
        line = 0
      }
    },
    source_offset = 1,
    source_replace_range = {
      ["end"] = {
        character = 1,
        line = 0
      },
      start = {
        character = 0,
        line = 0
      }
    },
    <metatable> = {
      __index = {
        execute = <function 61>,
        get_commit_characters = <function 62>,
        get_completion_item = <function 63>,
        get_documentation = <function 64>,
        get_filter_text = <function 65>,
        get_insert_range = <function 66>,
        get_insert_text = <function 67>,
        get_kind = <function 68>,
        get_offset = <function 69>,
        get_overwrite = <function 70>,
        get_replace_range = <function 71>,
        get_view = <function 72>,
        get_vim_item = <function 73>,
        get_word = <function 74>,
        is_deprecated = <function 75>,
        match = <function 76>,
        new = <function 77>,
        resolve = <function 78>
      }
    }
  }
}
```