### PR TITLE
Fix: fastwrap over end-line characters

### DIFF
--- a/lua/nvim-autopairs/fastwrap.lua
+++ b/lua/nvim-autopairs/fastwrap.lua
@@ -56,7 +56,6 @@ M.show = function(line)
         local index = 1
         local str_length = #line
         local offset = -1
-        local is_end_key = true
         for i = col + 2, #line, 1 do
             local char = line:sub(i, i)
             local char2 = line:sub(i - 1, i)
@@ -74,11 +73,6 @@ M.show = function(line)
                     offset = 0
                 end
 
-                if i == str_length then
-                    is_end_key = false
-                    key = config.end_key
-                    offset = 0
-                end
                 table.insert(
                     list_pos,
                     { col = i + offset, key = key, char = char, pos = i }
@@ -86,12 +80,10 @@ M.show = function(line)
             end
         end
 
-        if is_end_key then
-            table.insert(
-                list_pos,
-                { col = str_length + 1, key = config.end_key, pos = str_length + 1 }
-            )
-        end
+		table.insert(
+			list_pos,
+			{ col = str_length + 1, key = config.end_key, pos = str_length + 1 }
+		)
 
         M.highlight_wrap(list_pos, row, col, #line)
         vim.defer_fn(function()


### PR DESCRIPTION
## The problem
As mentionned in this issue: #247  
When a character matches at the end of the line, it overwrites the end key match and uses the end key symbol:
```lua
if i == str_length then
    is_end_key = false
    key = config.end_key
    offset = 0
end
```

This means, if you have a matching character at the end of the line (such as a semicolon), fastwrap will put the closing pair after the match instead of before it, which often isn't what you want:
```
Before       Fastwrap    Input    After
-------------------------------------------
(|)word;     (|)word$    $        (word;)
```

## The fix
This PR removes this behavior and makes an end match like any other match:
```
Before       Fastwrap     Input    After
-------------------------------------------
(|)word;     (|)wordq$    q        (word);
(|)word;     (|)wordq$    $        (word;)
```

## Other possible fix
By keeping the offset at -1 when overwriting the end key, the closing pair would be correctly put before the match:
```lua
if i == str_length then
    is_end_key = false
    key = config.end_key
    -- offset = 0
end
```
```
Before       Fastwrap    Input    After
-------------------------------------------
(|)word;     (|)word$    $        (word);
```

This allows 'instant' wraps over simple lines, but removes a bit of flexibility from the user (you might want to wrap a whole line in quotes, including the semicolon).  
A config option might be better here.