### PR TITLE
fix(cmp): Disable on_confirm_done for haskell

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -38,7 +38,8 @@ M.filetypes = {
             handler = handlers.lisp
         }
     },
-    tex = false
+    tex = false,
+    haskell = false
 }
 
 M.on_confirm_done = function(opts)


### PR DESCRIPTION
As Haskell does not use round brackets for function parameters on_confirm_done should be disabled for this filetype.

Thanks for the cool plugin :D