### PR TITLE
Return Rule table not Rule.new function

### DIFF
--- a/lua/nvim-autopairs/rule.lua
+++ b/lua/nvim-autopairs/rule.lua
@@ -13,8 +13,12 @@ local Cond = require('nvim-autopairs.conds')
 --- @field is_multibyte boolean
 --- @field is_endwise boolean        only use on end_wise
 --- @field is_undo boolean           add break undo sequence
-local Rule = {}
-Rule.__index = Rule
+
+local Rule = setmetatable({}, {
+  __call = function(self, ...)
+    return self.new(...)
+  end,
+})
 
 ---@return Rule
 function Rule.new(...)
@@ -218,4 +222,4 @@ function Rule:can_cr(opt)
     return can_do(self.cr_cond, opt)
 end
 
-return Rule.new
+return Rule


### PR DESCRIPTION
This allows configs to manipulate the Rule table, which can be used to override functions, make custom aliases, ...

`Rule.__index = Rule` was actually useless as `Rule` is never set as a metatable on rule instances.
Setting `Rule` as rule instances metadata would actually make `__call` work in too many cases like `my_rule(...)` which doesn't mean anything.

---
For example in my configs I want to use more readable function names instead of `with_*`, like so:
```lua
local Rule = require"nvim-autopairs.rule"
local cond = require"nvim-autopairs.conds"
Rule.insert_pair_when = Rule.with_pair
Rule.cr_expands_pair_when = Rule.with_cr
Rule.bs_deletes_pair_when = Rule.with_del
Rule.just_move_right_when = Rule.with_move
cond.never = cond.none()
cond.always = cond.done()
```