### PR TITLE
Remove duplicated %) in fast_wrap.pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ npairs.setup({
     fast_wrap = {
       map = '<M-e>',
       chars = { '{', '[', '(', '"', "'" },
-      pattern = [=[[%'%"%)%>%]%)%}%,]]=],
+      pattern = [=[[%'%"%>%]%)%}%,]]=],
       end_key = '$',
       keys = 'qwertyuiopzxcvbnmasdfghjkl',
       check_comma = true,

--- a/doc/nvim-autopairs.txt
+++ b/doc/nvim-autopairs.txt
@@ -393,7 +393,7 @@ FASTWRAP ~
         fast_wrap = {
           map = '<M-e>',
           chars = { '{', '[', '(', '"', "'" },
-          pattern = [=[[%'%"%)%>%]%)%}%,]]=],
+          pattern = [=[[%'%"%>%]%)%}%,]]=],
           end_key = '$',
           keys = 'qwertyuiopzxcvbnmasdfghjkl',
           check_comma = true,

--- a/lua/nvim-autopairs/fastwrap.lua
+++ b/lua/nvim-autopairs/fastwrap.lua
@@ -6,7 +6,7 @@ local M = {}
 local default_config = {
     map = '<M-e>',
     chars = { '{', '[', '(', '"', "'" },
-    pattern = [=[[%'%"%)%>%]%)%}%,]]=],
+    pattern = [=[[%'%"%>%]%)%}%,]]=],
     end_key = '$',
     keys = 'qwertyuiopzxcvbnmasdfghjkl',
     highlight = 'Search',


### PR DESCRIPTION
`%)` was actually present twice!

---
This fast wrap system is REALLY COOL :heart: 
Also I think `fast_wrap.*` options would really benefit from being documented!
(I also have few ideas of things to add there, will probably make issues/PR at some point)