### PR TITLE
fix deprecated ts_utils is_in_node_range

### DIFF
--- a/lua/nvim-autopairs/ts-conds.lua
+++ b/lua/nvim-autopairs/ts-conds.lua
@@ -78,7 +78,7 @@ conds.is_in_range = function(callback, position)
 
         for _, tree in ipairs(lang_tree:trees()) do
             local root = tree:root()
-            if root and ts_utils.is_in_node_range(root, line, col) then
+            if root and vim.treesitter.is_in_node_range(root, line, col) then
                 local node = root:named_descendant_for_range(line, col, line, col)
                 local anonymous_node = root:descendant_for_range(
                     line,


### PR DESCRIPTION
ts_utils.is_in_node_range is now deprecated (as get_node_range)

see: https://github.com/nvim-treesitter/nvim-treesitter/pull/4300