### PR TITLE
Recognize angle brackets (<>) as brackets in util functions

### DIFF
--- a/lua/nvim-autopairs/utils.lua
+++ b/lua/nvim-autopairs/utils.lua
@@ -26,12 +26,12 @@ M.is_quote = function (char)
 end
 
 M.is_bracket = function (char)
-    return char == "(" or char == '[' or char == '{'
+    return char == "(" or char == '[' or char == '{' or char == '<'
 end
 
 
 M.is_close_bracket = function (char)
-    return char == ")" or char == ']' or char == '}'
+    return char == ")" or char == ']' or char == '}' or char == '>'
 end
 
 M.compare = function (value, text, is_regex)


### PR DESCRIPTION
I wanted to re-use `nvim-autopairs.rules.basic.bracket_creator()` to make some patterns for myself for Rust (e.g. `Vec<u32>` and `<T: AsRef<String>>` but noticed that `utils.is_bracket()` and `.is_close_bracket()` didn't list angled brackets so I added them. 

Perhaps this could be useful for others as well :)