### PR TITLE
README: update default value for disable_filetype option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ use {
 ## Default values
 
 ``` lua
-local disable_filetype = { "TelescopePrompt" }
+local disable_filetype = { "TelescopePrompt", "spectre_panel" }
 local disable_in_macro = false  -- disable when recording or executing a macro
 local disable_in_visualblock = false -- disable when insert after visual block mode
 local disable_in_replace_mode = true
@@ -343,7 +343,7 @@ Before        Input         After
   require('nvim-autopairs').remove_rule('(') -- remove rule (
   require('nvim-autopairs').clear_rules() -- clear all rules
   -- get rule " then modify it. It can return a list of rule or just a rule
-  require('nvim-autopairs').get_rule('"') 
+  require('nvim-autopairs').get_rule('"')
 ```
 
 * Sample


### PR DESCRIPTION
Looking at [the source code](https://github.com/windwp/nvim-autopairs/blob/6a5faeabdbcc86cfbf1561ae430a451a72126e81/lua/nvim-autopairs.lua#L19), it seems that the default value for the `disable_filetype` option is `{ "TelescopePrompt", "spectre_panel" }`.
I updated the README.md with this correct value.