### PR TITLE
fix(cmp): don't insert parentheses on non-keymapped confirms

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -49,6 +49,10 @@ M.on_confirm_done = function(opts)
     }, opts or {})
 
     return function(evt)
+        if evt.commit_character then
+          return
+        end
+        
         local entry = evt.entry
         local commit_character = entry:get_commit_characters()
         local bufnr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
The `confirm_done` event can be triggered by keys outside of the keymap (`<CR>`, etc.) which can cause bugs like double parentheses.

This fix adds a check to `commit_character`, which will be non-nil in those cases.