### PR TITLE
fix: don't clear rules after closing floating win

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -62,7 +62,11 @@ M.setup = function(opt)
     api.nvim_create_autocmd('BufDelete', {
         group = group, pattern = '*',
         callback = function(data)
-            M.set_buf_rule(nil, tonumber(data.buf) or 0)
+            local cur = api.nvim_get_current_buf()
+            local bufnr = tonumber(data.buf) or 0
+            if bufnr ~= cur then
+                M.set_buf_rule(nil, bufnr)
+            end
         end,
     })
     api.nvim_create_autocmd('FileType', {


### PR DESCRIPTION
When `BufDelete` is triggered after closing a floating window such as one from `vim-floaterm`, the `bufnr` the event gets is that of the file you're editing, not the buffer for the terminal, which is causing this autocommand to clear the rules for the current file.

Making sure the buffer we're clearing rules for isn't the buffer we're currently on fixes the issue for me, and seems to make sense because I would imagine the buffer we're currently looking at isn't the buffer that we just deleted and thus triggered a `BufDelete` event.

This should also fix https://github.com/windwp/nvim-autopairs/issues/293 as it seems to be the same issue.