### PR TITLE
Do not move right when char is not valid for rule

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -434,7 +434,12 @@ M.autopairs_map = function(bufnr, char)
             -- log.debug("start_pair" .. rule.start_pair)
             -- log.debug('prev_char' .. prev_char)
             -- log.debug('next_char' .. next_char)
-            if utils.compare(rule.end_pair, next_char, rule.is_regex)
+            local char_matches_rule = (rule.end_pair == char or rule.key_map == char)
+            -- for simple pairs, char will match end_pair
+            -- for more complex pairs, user should map the wanted end char with `use_key`
+            --   on a dedicated rule
+            if char_matches_rule
+                and utils.compare(rule.end_pair, next_char, rule.is_regex)
                 and rule:can_move(cond_opt)
             then
                 local end_pair = rule:get_end_pair(cond_opt)

--- a/tests/nvim-autopairs_spec.lua
+++ b/tests/nvim-autopairs_spec.lua
@@ -170,6 +170,36 @@ local data = {
         after  = [[("abcd}|} ]]
     },
     {
+        -- ref: issue #331
+        name = "move right, should not move on non-end-pair char: `§|§` with (" ,
+        setup_func = function()
+          npairs.add_rule(Rule("§","§"):with_move(cond.done()))
+        end,
+        key    = [[(]],
+        before = [[§|§]],
+        after  = [[§(|)§]]
+    },
+    {
+        -- ref: issue #331
+        name = "move right, should not move on non-end-pair char: `#|#` with \"" ,
+        setup_func = function()
+          npairs.add_rule(Rule("#","#"):with_move(cond.done()))
+        end,
+        key    = [["]],
+        before = [[#|#]],
+        after  = [[#"|"#]]
+    },
+    {
+        -- ref: issue #331 and #330
+        name = "move right, should not move on non-end-pair char: `<|>` with (" ,
+        setup_func = function()
+          npairs.add_rule(Rule("<",">"):with_move(cond.done()))
+        end,
+        key    = [[(]],
+        before = [[<|>]],
+        after  = [[<(|)>]],
+    },
+    {
         name = "move right when inside grave with special slash" ,
         key    = [[`]],
         before = [[(`abcd\"|`)]],


### PR DESCRIPTION
The issue was that when checking if we should move right, the current char was never checked to be valid for the current rule.

Fixes #331

I didn't manage to run the tests locally, this is why I made many commits & used the CI to test :eyes:

~Only 1 test is failing, and I don't understand why, see the comment below~