### PR TITLE
feat: add rule for handling brackets in Rust

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -41,6 +41,7 @@ local function setup(opt)
         Rule("```.*$", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc" }):only_cr():use_regex(true),
         Rule('"""', '"""', { "python", "elixir", "julia", "kotlin" }):with_pair(cond.not_before_char('"', 3)),
         Rule("'''", "'''", { "python" }):with_pair(cond.not_before_char('"', 3)),
+        Rule("<", ">", "rust"):with_pair(cond.before_regex("%a+")):with_move(function(opts) return opts.char == ">" end),
         quote("'", "'", "-rust"):with_pair(cond.not_before_regex("%w")),
         quote("'", "'", "rust"):with_pair(cond.not_before_regex("[%w<&]")):with_pair(cond.not_after_text(">")),
         quote("`", "`"),


### PR DESCRIPTION
Retrieved from here: https://github.com/windwp/nvim-autopairs/issues/330#issuecomment-1550194555

It seems to work well, so this would be nice to have as a standard rule for Rust users.