### PR TITLE
fix: prevent conds lambda from caching the first length parameter

### DIFF
--- a/lua/nvim-autopairs/conds.lua
+++ b/lua/nvim-autopairs/conds.lua
@@ -37,19 +37,14 @@ cond.invert = function(func)
     end
 end
 
-cond.before_regex = function(regex, length)
-    length = length or 1
+cond.before_regex = function(regex)
     if not regex then
         return cond.none()
     end
     ---@param opts CondOpts
     return function(opts)
         log.debug('before_regex')
-        local captured_length = length
-        if captured_length < 0 then
-            captured_length = opts.col
-        end
-        local str = utils.text_sub_char(opts.line, opts.col - 1, -captured_length)
+        local str = utils.text_sub_char(opts.line, opts.col - 1, -opts.col)
         if str:match(regex) then
             return true
         end
@@ -83,19 +78,14 @@ cond.after_text = function(text)
     end
 end
 
-cond.after_regex = function(regex, length)
-    length = length or 1
+cond.after_regex = function(regex)
     if not regex then
         return cond.none()
     end
     ---@param opts CondOpts
     return function(opts)
         log.debug('after_regex')
-        local captured_length = length
-        if captured_length < 0 then
-            captured_length = #opts.line
-        end
-        local str = utils.text_sub_char(opts.line, opts.col, captured_length)
+        local str = utils.text_sub_char(opts.line, opts.col, #opts.line)
         if str:match(regex) then
             return true
         end
@@ -126,38 +116,28 @@ cond.not_after_text = function(text)
     end
 end
 
-cond.not_before_regex = function(regex, length)
-    length = length or 1
+cond.not_before_regex = function(regex)
     if not regex then
         return cond.none()
     end
     ---@param opts CondOpts
     return function(opts)
         log.debug('not_before_regex')
-        local captured_length = length
-        if captured_length < 0 then
-            captured_length = opts.col
-        end
-        local str = utils.text_sub_char(opts.line, opts.col - 1, -captured_length)
+        local str = utils.text_sub_char(opts.line, opts.col - 1, -opts.col)
         if str:match(regex) then
             return false
         end
     end
 end
 
-cond.not_after_regex = function(regex, length)
-    length = length or 1
+cond.not_after_regex = function(regex)
     if not regex then
         return cond.none()
     end
     ---@param opts CondOpts
     return function(opts)
         log.debug('not_after_regex')
-        local captured_length = length
-        if captured_length < 0 then
-            captured_length = #opts.line
-        end
-        local str = utils.text_sub_char(opts.line, opts.col, captured_length)
+        local str = utils.text_sub_char(opts.line, opts.col, #opts.line)
         if str:match(regex) then
             return false
         end

--- a/lua/nvim-autopairs/conds.lua
+++ b/lua/nvim-autopairs/conds.lua
@@ -45,10 +45,11 @@ cond.before_regex = function(regex, length)
     ---@param opts CondOpts
     return function(opts)
         log.debug('before_regex')
-        if length < 0 then
-            length = opts.col
+        local captured_length = length
+        if captured_length < 0 then
+            captured_length = opts.col
         end
-        local str = utils.text_sub_char(opts.line, opts.col - 1, -length)
+        local str = utils.text_sub_char(opts.line, opts.col - 1, -captured_length)
         if str:match(regex) then
             return true
         end
@@ -90,10 +91,11 @@ cond.after_regex = function(regex, length)
     ---@param opts CondOpts
     return function(opts)
         log.debug('after_regex')
-        if length < 0 then
-            length = #opts.line
+        local captured_length = length
+        if captured_length < 0 then
+            captured_length = #opts.line
         end
-        local str = utils.text_sub_char(opts.line, opts.col, length)
+        local str = utils.text_sub_char(opts.line, opts.col, captured_length)
         if str:match(regex) then
             return true
         end
@@ -132,10 +134,11 @@ cond.not_before_regex = function(regex, length)
     ---@param opts CondOpts
     return function(opts)
         log.debug('not_before_regex')
-        if length < 0 then
-            length = opts.col
+        local captured_length = length
+        if captured_length < 0 then
+            captured_length = opts.col
         end
-        local str = utils.text_sub_char(opts.line, opts.col - 1, -length)
+        local str = utils.text_sub_char(opts.line, opts.col - 1, -captured_length)
         if str:match(regex) then
             return false
         end
@@ -150,10 +153,11 @@ cond.not_after_regex = function(regex, length)
     ---@param opts CondOpts
     return function(opts)
         log.debug('not_after_regex')
-        if length < 0 then
-            length = #opts.line
+        local captured_length = length
+        if captured_length < 0 then
+            captured_length = #opts.line
         end
-        local str = utils.text_sub_char(opts.line, opts.col, length)
+        local str = utils.text_sub_char(opts.line, opts.col, captured_length)
         if str:match(regex) then
             return false
         end

--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -7,7 +7,7 @@ local function quote_creator(opt)
         local rule = Rule(...):with_move(move_func()):with_pair(cond.not_add_quote_inside_quote())
 
         if #opt.ignored_next_char > 1 then
-            rule:with_pair(cond.not_after_regex(opt.ignored_next_char))
+            rule:with_pair(cond.not_after_regex(opt.ignored_next_char .. '$'))
         end
         rule:use_undo(opt.break_undo)
         return rule
@@ -41,11 +41,11 @@ local function setup(opt)
         Rule("```.*$", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc" }):only_cr():use_regex(true),
         Rule('"""', '"""', { "python", "elixir", "julia", "kotlin" }):with_pair(cond.not_before_char('"', 3)),
         Rule("'''", "'''", { "python" }):with_pair(cond.not_before_char('"', 3)),
-        quote("'", "'", "-rust"):with_pair(cond.not_before_regex("%w")),
-        quote("'", "'", "rust"):with_pair(cond.not_before_regex("[%w<&]")):with_pair(cond.not_after_text(">")),
+        quote("'", "'", "-rust"):with_pair(cond.not_before_regex("%w$")),
+        quote("'", "'", "rust"):with_pair(cond.not_before_regex("[%w<&]$")):with_pair(cond.not_after_text(">")),
         quote("`", "`"),
         quote('"', '"', "-vim"),
-        quote('"', '"', "vim"):with_pair(cond.not_before_regex("^%s*$", -1)),
+        quote('"', '"', "vim"):with_pair(cond.not_before_regex("^%s*$")),
         bracket("(", ")"),
         bracket("[", "]"),
         bracket("{", "}"),

--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -7,7 +7,7 @@ local function quote_creator(opt)
         local rule = Rule(...):with_move(move_func()):with_pair(cond.not_add_quote_inside_quote())
 
         if #opt.ignored_next_char > 1 then
-            rule:with_pair(cond.not_after_regex(opt.ignored_next_char .. '$'))
+            rule:with_pair(cond.not_after_regex('^' .. opt.ignored_next_char))
         end
         rule:use_undo(opt.break_undo)
         return rule


### PR DESCRIPTION
Problem:

I faced this issue when trying to write a simple rule for a block comment:

```lua
      npairs.add_rule(
        Rule('/**', '  */')
        :with_pair(cond.not_after_regex('.-%*/', -1))
        :set_end_pair_length(3)
      )
```

This rule kept failing and I thought I was going insane or just dumb but it turns out due to the odd nature of how variables are captured in lua. The first time that the `not_after_regex` function is run it instantiates the function to be returned with the *cached* value of `length`, and this is essentially always going to be the referenced value from within the returned function. I.e.:

```lua
cond.not_after_regex = function(regex, length)
    length = length or 1
    if not regex then
        return cond.none()
    end
    ---@param opts CondOpts
    return function(opts)
        log.debug('not_after_regex')
        if length < 0 then
            length = #opts.line
            -- LENGTH and #OPTS.LINE ARE NOT ALWAYS EQUAL HERE
        end
        local str = utils.text_sub_char(opts.line, opts.col, length)
        if str:match(regex) then
            return false
        end
    end
end
```

This is what caused my rule to fail. Instantiation a new local variable from within the returned lambda function fixes this issue in my testing, and I implemented it in the other regex related conditions as well.

```lua
cond.not_after_regex = function(regex, length)
    length = length or 1
    if not regex then
        return cond.none()
    end
    ---@param opts CondOpts
    return function(opts)
        log.debug('not_after_regex')
        local captured_length = length
        if captured_length < 0 then
            captured_length = #opts.line
            -- WORKS
        end
        local str = utils.text_sub_char(opts.line, opts.col, captured_length)
        if str:match(regex) then
            return false
        end
    end
end
```

 Really hope this can get merged, thank you