### PR TITLE
fix: prevent potential arithmetic operation against nil

### DIFF
--- a/lua/nvim-autopairs/conds.lua
+++ b/lua/nvim-autopairs/conds.lua
@@ -43,7 +43,7 @@ cond.before_regex = function(regex, length)
     ---@param opts CondOpts
     return function(opts)
         log.debug('before_regex')
-        local str = utils.text_sub_char(opts.line, opts.col - 1, length - opts.col)
+        local str = utils.text_sub_char(opts.line, opts.col - 1, length or -opts.col)
         if str:match(regex) then
             return true
         end


### PR DESCRIPTION
Hi thanks for patching things up with the `length` parameter; sorry to bother one last time but I believe there was a small bug in the latest commit that would cause an error saying there was an attempt to perform arithmetic on a nil value. Should be fine with this commit