### PR TITLE
fix: support htmldjango in basic tag rule

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -53,6 +53,7 @@ local function setup(opt)
             "^%s*</",
             {
                 "html",
+                "htmldjango",
                 "php",
                 "typescript",
                 "typescriptreact",


### PR DESCRIPTION
htmldjango files should also be supported with basic tags.

I think not having a specified table of filetypes for stuff like this is not a good idea, but it works for now.