### PR TITLE
made the plugin move the cursor less

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -567,12 +567,10 @@ M.autopairs_cr = function(bufnr)
                 and rule:can_cr(cond_opt)
             then
                 local end_pair = rule:get_end_pair(cond_opt)
-                local end_pair_length = rule:get_end_pair_length(end_pair)
                 return utils.esc(
-                    end_pair
-                    .. utils.repeat_key(utils.key.join_left, end_pair_length)
+                    '<CR>' .. end_pair
                     -- FIXME do i need to re indent twice #118
-                    .. '<cr><esc>====O'
+                    .. '<CMD>normal ====k$<CR><right><CR>'
                 )
             end
 
@@ -583,7 +581,7 @@ M.autopairs_cr = function(bufnr)
                 and rule:can_cr(cond_opt)
             then
                 log.debug('do_cr')
-                return utils.esc(rule:get_map_cr({ rule = rule, line = line, color = col, bufnr = bufnr }))
+                return utils.esc('<CR><CMD>normal ====k$<CR><right><CR>')
             end
         end
     end

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -470,7 +470,9 @@ M.autopairs_map = function(bufnr, char)
                 end
                 api.nvim_feedkeys(result, "tn", false) --t mode makes it send the keys right away n more is for noremap
                 --not sure how to convert bufnr to a win id 
-                api.nvim_win_set_cursor(0, {row,col})
+                print(row,col)
+                api.nvim_win_set_cursor(0, {row,col + #char})
+                abort() -- lua is such a good language
                 log.debug("key_map :" .. result)
                 return ''
             end

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -581,7 +581,7 @@ M.autopairs_cr = function(bufnr)
                 and rule:can_cr(cond_opt)
             then
                 log.debug('do_cr')
-                return utils.esc('<CR><CMD>normal ====k$<CR><right><CR>')
+                return utils.esc(rule:get_map_cr({ rule = rule, line = line, color = col, bufnr = bufnr }))
             end
         end
     end

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -470,9 +470,7 @@ M.autopairs_map = function(bufnr, char)
                 end
                 api.nvim_feedkeys(result, "tn", false) --t mode makes it send the keys right away n more is for noremap
                 --not sure how to convert bufnr to a win id 
-                print(row,col)
-                api.nvim_win_set_cursor(0, {row,col + #char})
-                abort() -- lua is such a good language
+                api.nvim_win_set_cursor(0, {row,col})
                 log.debug("key_map :" .. result)
                 return ''
             end

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -56,13 +56,11 @@ M.setup = function(opt)
     M.force_attach()
     local group = api.nvim_create_augroup('autopairs_buf', { clear = true })
     api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
-        group = group,
-        pattern = '*',
+        group = group, pattern = '*',
         callback = function() M.on_attach() end
     })
     api.nvim_create_autocmd('BufDelete', {
-        group = group,
-        pattern = '*',
+        group = group, pattern = '*',
         callback = function(data)
             local cur = api.nvim_get_current_buf()
             local bufnr = tonumber(data.buf) or 0
@@ -72,8 +70,7 @@ M.setup = function(opt)
         end,
     })
     api.nvim_create_autocmd('FileType', {
-        group = group,
-        pattern = '*',
+        group = group, pattern = '*',
         callback = function() M.force_attach() end
     })
 end
@@ -401,7 +398,7 @@ M.autopairs_map = function(bufnr, char)
         return char
     end
     local line = utils.text_get_current_line(bufnr)
-    local row, col = utils.get_cursor()
+    local _, col = utils.get_cursor()
     local new_text = ''
     local add_char = 1
     local rules = M.get_buf_rules(bufnr)
@@ -455,24 +452,24 @@ M.autopairs_map = function(bufnr, char)
                 and rule:can_pair(cond_opt)
             then
                 local end_pair = rule:get_end_pair(cond_opt)
+                local end_pair_length = rule:get_end_pair_length(end_pair)
+                local move_text = utils.repeat_key(utils.key.join_left, end_pair_length)
                 if add_char == 0 then
+                    move_text = ''
                     char = ''
                 end
                 if end_pair:match('<.*>') then
                     end_pair = utils.esc(end_pair)
                 end
-                local result = char .. end_pair
+                local result = char .. end_pair .. utils.esc(move_text)
                 if rule.is_undo then
                     result = utils.esc(utils.key.undo_sequence) .. result .. utils.esc(utils.key.undo_sequence)
                 end
                 if M.config.enable_abbr then
                     result = utils.esc(utils.key.abbr) .. result
                 end
-                api.nvim_feedkeys(result, "tn", false) --t mode makes it send the keys right away n more is for noremap
-                --not sure how to convert bufnr to a win id 
-                api.nvim_win_set_cursor(0, {row,col})
                 log.debug("key_map :" .. result)
-                return ''
+                return result
             end
         end
     end

--- a/lua/nvim-autopairs/rule.lua
+++ b/lua/nvim-autopairs/rule.lua
@@ -114,7 +114,7 @@ function Rule:get_map_cr(opts)
     if self.map_cr_func then
         return self.map_cr_func(opts)
     end
-    return '<CMD>normal ==k$<CR><right><CR>'
+    return '<CR><CMD>normal ==k$<CR><right><CR>'
 end
 
 function Rule:replace_map_cr(value)

--- a/lua/nvim-autopairs/rule.lua
+++ b/lua/nvim-autopairs/rule.lua
@@ -114,9 +114,8 @@ function Rule:get_map_cr(opts)
     if self.map_cr_func then
         return self.map_cr_func(opts)
     end
-    return '<CR><CMD>normal ==k$<CR><right><CR>'
+    return '<c-g>u<CR><CMD>normal ==k$<CR><right><CR>'
 end
-
 function Rule:replace_map_cr(value)
     self.map_cr_func = value
     return self

--- a/lua/nvim-autopairs/rule.lua
+++ b/lua/nvim-autopairs/rule.lua
@@ -15,9 +15,9 @@ local Cond = require('nvim-autopairs.conds')
 --- @field is_undo boolean           add break undo sequence
 
 local Rule = setmetatable({}, {
-  __call = function(self, ...)
-    return self.new(...)
-  end,
+    __call = function(self, ...)
+        return self.new(...)
+    end,
 })
 
 ---@return Rule
@@ -114,7 +114,7 @@ function Rule:get_map_cr(opts)
     if self.map_cr_func then
         return self.map_cr_func(opts)
     end
-    return '<c-g>u<cr><c-c>==O'
+    return '<CMD>normal ==k$<CR><right><CR>'
 end
 
 function Rule:replace_map_cr(value)
@@ -173,7 +173,7 @@ end
 ---@return Rule
 function Rule:with_pair(cond, pos)
     if self.pair_cond == nil then self.pair_cond = {} end
-    self.pair_cond[pos or (#self.pair_cond+1)] = cond
+    self.pair_cond[pos or (#self.pair_cond + 1)] = cond
     return self
 end
 


### PR DESCRIPTION
i made an issue about this #390 but i was bit scared of making a pull request (thought i would break something)
then i tested the plugin at bit with my own fork everything seemed fine so i made this

tl;dr
when pairs expand they draw the cursor twice (for like half a frame)
```
{
|     |
}
```
i made a work around using \<cmd\> as it doesn't trigger a cursor redraw(or switch modes)
but to use normal mode functions i had to use `normal` which does switch modes but doesn't redraw the cursor

i made a version that fully works in insert mode in my own plugin but doesn't indent none {} pairs properly
https://github.com/Sam-programs/autopairs.nvim/blob/main/lua/autopairs.lua#L352
i wasn't able to replicate the == motion perfectly with functions