### PR TITLE
cmd hack to not move the cursor and a fix for recursive mapping

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -570,7 +570,7 @@ M.autopairs_cr = function(bufnr)
                 return utils.esc(
                     '<CR>' .. end_pair
                     -- FIXME do i need to re indent twice #118
-                    .. '<CMD>normal ====k$<CR><right><CR>'
+                    .. '<CMD>normal! ====<CR><up><end><CR>'
                 )
             end
 

--- a/lua/nvim-autopairs/rule.lua
+++ b/lua/nvim-autopairs/rule.lua
@@ -114,7 +114,7 @@ function Rule:get_map_cr(opts)
     if self.map_cr_func then
         return self.map_cr_func(opts)
     end
-    return '<c-g>u<CR><CMD>normal ==k$<CR><right><CR>'
+    return '<c-g>u<CR><CMD>normal! ====<CR><up><end><CR>'
 end
 function Rule:replace_map_cr(value)
     self.map_cr_func = value


### PR DESCRIPTION
this fixes =,$ and k  mappings being broken (which i made sorry users)
and doesn't move the cursor on custom pairs with a cmd hack
more info:
https://github.com/windwp/nvim-autopairs/pull/394

so yeah here is the new pr with more sane commits windwp
i doubt the test on line 82 of test_utils is gonna pass tho _it's probably safe to remove_