### PR TITLE
on_cr fully in insert mode!

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -555,14 +555,6 @@ M.enable_ctrl_f_formatting = function()
     end
 end
 
-M.restore_user_configuration = function()
-    vim.o.cindent = M.old_cindent
-    vim.o.cinkeys = M.old_cinkeys 
-    vim.o.indentexpr = M.old_indentexpr
-    vim.o.indentkeys = M.old_indentkeys
-end
-
-
 M.autopairs_cr = function(bufnr)
     if is_disable() then
         return utils.esc('<cr>')
@@ -600,12 +592,12 @@ M.autopairs_cr = function(bufnr)
                 and rule:can_cr(cond_opt)
             then
                 local end_pair = rule:get_end_pair(cond_opt)
-                M.enable_ctrl_f_formatting()
+                utils.enable_ctrl_f_formatting()
                 return utils.esc(
                     '<CR><CR>' .. end_pair ..
                     -- FIXME do i need to re indent twice #118
                     '<C-f><C-f><up><C-f>' ..
-                    '<cmd>lua require(\'nvim-autopairs\').restore_user_configuration()<cr>'
+                    '<cmd>lua require(\'nvim-autopairs.utils\').restore_user_configuration()<cr>'
                 )
             end
 

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -533,28 +533,6 @@ M.autopairs_insert = function(bufnr, char)
     return char
 end
 
-M.enable_ctrl_f_formatting = function()
-    M.old_cinkeys = vim.o.cinkeys
-    M.old_indentkeys = vim.o.indentkeys
-    M.old_cindent = vim.o.cindent
-    M.old_indentexpr = vim.o.indentexpr
-    if vim.o.filetype == 'lisp' then
-        vim.cmd(
-            'if !exists("*GetLispIndent")\n' ..
-            'function GetLispIndent() \n' ..
-            'return lispindent(v:lnum) \n' ..
-            'endfunction\n' ..
-            'endif \n')
-        vim.o.indentexpr = 'GetLispIndent()'
-    end
-    if vim.o.indentexpr ~= '' then
-        vim.o.indentkeys = '!^F'
-    else
-        vim.o.cinkeys = '!^F'
-        vim.o.cindent = true
-    end
-end
-
 M.autopairs_cr = function(bufnr)
     if is_disable() then
         return utils.esc('<cr>')

--- a/lua/nvim-autopairs/rule.lua
+++ b/lua/nvim-autopairs/rule.lua
@@ -114,9 +114,9 @@ function Rule:get_map_cr(opts)
     if self.map_cr_func then
         return self.map_cr_func(opts)
     end
-    require('nvim-autopairs').enable_ctrl_f_formatting()
+    require('nvim-autopairs.utils').enable_ctrl_f_formatting()
     return '<c-g>u<CR><CR><C-f><C-f><up><C-f><c-g>u' ..
-        '<cmd>lua require(\'nvim-autopairs\').restore_user_configuration()<cr>'
+        '<cmd>lua require(\'nvim-autopairs.utils\').restore_user_configuration()<cr>'
 end
 
 function Rule:replace_map_cr(value)

--- a/lua/nvim-autopairs/rule.lua
+++ b/lua/nvim-autopairs/rule.lua
@@ -114,8 +114,11 @@ function Rule:get_map_cr(opts)
     if self.map_cr_func then
         return self.map_cr_func(opts)
     end
-    return '<c-g>u<CR><CMD>normal! ====<CR><up><end><CR>'
+    require('nvim-autopairs').enable_ctrl_f_formatting()
+    return '<c-g>u<CR><CR><C-f><C-f><up><C-f><c-g>u' ..
+        '<cmd>lua require(\'nvim-autopairs\').restore_user_configuration()<cr>'
 end
+
 function Rule:replace_map_cr(value)
     self.map_cr_func = value
     return self

--- a/lua/nvim-autopairs/utils.lua
+++ b/lua/nvim-autopairs/utils.lua
@@ -195,4 +195,33 @@ M.get_prev_char = function(opt)
     return opt.line:sub(opt.col - 1, opt.col + #opt.rule.start_pair - 2)
 end
 
+M.enable_ctrl_f_formatting = function()
+    M.old_cinkeys = vim.o.cinkeys
+    M.old_indentkeys = vim.o.indentkeys
+    M.old_cindent = vim.o.cindent
+    M.old_indentexpr = vim.o.indentexpr
+    if vim.o.filetype == 'lisp' then
+        vim.cmd(
+            'if !exists("*GetLispIndent")\n' ..
+            'function GetLispIndent() \n' ..
+            'return lispindent(v:lnum) \n' ..
+            'endfunction\n' ..
+            'endif \n')
+        vim.o.indentexpr = 'GetLispIndent()'
+    end
+    if vim.o.indentexpr ~= '' then
+        vim.o.indentkeys = '!^F'
+    else
+        vim.o.cinkeys = '!^F'
+        vim.o.cindent = true
+    end
+end
+
+M.restore_user_configuration = function()
+    vim.o.cindent = M.old_cindent
+    vim.o.cinkeys = M.old_cinkeys 
+    vim.o.indentexpr = M.old_indentexpr
+    vim.o.indentkeys = M.old_indentkeys
+end
+
 return M

--- a/lua/nvim-autopairs/utils.lua
+++ b/lua/nvim-autopairs/utils.lua
@@ -200,7 +200,8 @@ M.enable_ctrl_f_formatting = function()
     M.old_indentkeys = vim.o.indentkeys
     M.old_cindent = vim.o.cindent
     M.old_indentexpr = vim.o.indentexpr
-    if vim.o.filetype == 'lisp' then
+    -- incase they set a custom lisp formatter
+    if vim.o.indentexpr == '' and vim.o.filetype == 'lisp' then
         vim.cmd(
             'if !exists("*GetLispIndent")\n' ..
             'function GetLispIndent() \n' ..


### PR DESCRIPTION
after carefully reading most of `indent.txt`

i found a way to make Return expansion work fully in insert mode with keys,
using `cinkeys` and `indentkeys`

```vimdoc
={motion}   Filter {motion} lines through the external program
			given with the 'equalprg' option.  When the 'equalprg'
			option is empty (this is the default), use the
			internal formatting function |C-indenting| and
			|'lisp'|.  But when 'indentexpr' is not empty, it will
			be used instead |indent-expression|.
```
i replicated in insert everything except for equalprg as am not sure how it can be helpful, since we are only indenting 1 line

i also changed the way pairs are placed
```
     {

|} format

     {
| format to set the cursor position
     }
```