### PR TITLE
smoother custom pairs

### DIFF
--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -461,9 +461,6 @@ M.autopairs_map = function(bufnr, char)
                 if end_pair:match('<.*>') then
                     end_pair = utils.esc(end_pair)
                 end
-                -- don't redraw the cursor twice
-                OLD_lazyredraw = vim.o.lz
-                vim.o.lazyredraw = true
                 local result = char .. end_pair .. utils.esc(move_text)
                 if rule.is_undo then
                     result = utils.esc(utils.key.undo_sequence) .. result .. utils.esc(utils.key.undo_sequence)
@@ -471,7 +468,10 @@ M.autopairs_map = function(bufnr, char)
                 if M.config.enable_abbr then
                     result = utils.esc(utils.key.abbr) .. result
                 end
-                result = result .. utils.esc('<cmd>lua vim.o.lazyredraw = OLD_lazyredraw<cr>')
+                -- don't redraw the cursor twice
+                local old_lazyredraw = vim.o.lazyredraw
+                vim.o.lazyredraw = true
+                result = result .. utils.esc("<cmd>lua vim.o.lazyredraw =" .. (old_lazyredraw and "true" or "false") .. "<cr>")
                 log.debug("key_map :" .. result)
                 return result
             end

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -461,6 +461,9 @@ M.autopairs_map = function(bufnr, char)
                 if end_pair:match('<.*>') then
                     end_pair = utils.esc(end_pair)
                 end
+                -- don't redraw the cursor twice
+                OLD_lazyredraw = vim.o.lz
+                vim.o.lazyredraw = true
                 local result = char .. end_pair .. utils.esc(move_text)
                 if rule.is_undo then
                     result = utils.esc(utils.key.undo_sequence) .. result .. utils.esc(utils.key.undo_sequence)
@@ -468,6 +471,7 @@ M.autopairs_map = function(bufnr, char)
                 if M.config.enable_abbr then
                     result = utils.esc(utils.key.abbr) .. result
                 end
+                result = result .. utils.esc('<cmd>lua vim.o.lazyredraw = OLD_lazyredraw<cr>')
                 log.debug("key_map :" .. result)
                 return result
             end


### PR DESCRIPTION
https://github.com/windwp/nvim-autopairs/pull/396
sorry for bringing this up again but i tested nvim_win_set_cursor and it never broke the undo blocks only arrow keys broke them
```lua
vim.keymap.set("i", "<C-r>", function()
   local set_cursor = vim.api.nvim_win_set_cursor
   local r,c = unpack(vim.api.nvim_win_get_cursor(0))
   set_cursor(0,{r,c + 1})
   set_cursor(0,{r - 1,c + 2})
   set_cursor(0,{r - 1,c - 2})
   set_cursor(0,{1,0})
   set_cursor(0,{r,c})
end)
```
jump_to_last_pair is safe to add to make custom pairs smoother
