### PR TITLE
fix(#388) force pairs to work with pyright

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -14,6 +14,12 @@ M.filetypes = {
             handler = handlers["*"]
         }
     },
+    python = {
+        ["("] = {
+            kind = { Kind.Function, Kind.Method },
+            handler = handlers.python
+        }
+    },
     clojure = {
         ["("] = {
             kind = { Kind.Function, Kind.Method },

--- a/lua/nvim-autopairs/completion/handlers.lua
+++ b/lua/nvim-autopairs/completion/handlers.lua
@@ -81,4 +81,9 @@ M.lisp = function (char, item, bufnr, _, _)
   utils.feed("<Space>")
 end
 
+M.python = function(char, item, bufnr, rules, _)
+   item.data.funcParensDisabled = false
+   M["*"](char,item,bufnr,rules)
+end
+
 return M


### PR DESCRIPTION
this just sets funcParensDisabled to false to fixing https://github.com/windwp/nvim-autopairs/issues/388
```lua
M.python = function(char, item, bufnr, rules, _)
   item.data.funcParensDisabled = false
   M["*"](char,item,bufnr,rules)
end
```