### PR TITLE
feat(cpp <> pairs) auto add <> for templates,includes and templated types

### DIFF
--- a/doc/nvim-autopairs.txt
+++ b/doc/nvim-autopairs.txt
@@ -99,6 +99,8 @@ Check readme.md on nvim-cmp repo.
       'confirm_done',
       cmp_autopairs.on_confirm_done()
     )
+    -- if u want to insert <> pairs after templates, include and templated types
+    cmp.event:on('confirm_done', cmp_autopairs.cpp_pairs())
 <
 
 

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -1,6 +1,7 @@
 local autopairs = require('nvim-autopairs')
 local handlers = require('nvim-autopairs.completion.handlers')
 local cmp = require('cmp')
+local utils = require('nvim-autopairs.utils')
 
 local Kind = cmp.lsp.CompletionItemKind
 

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -1,7 +1,6 @@
 local autopairs = require('nvim-autopairs')
 local handlers = require('nvim-autopairs.completion.handlers')
 local cmp = require('cmp')
-local utils = require('nvim-autopairs.utils')
 
 local Kind = cmp.lsp.CompletionItemKind
 
@@ -53,7 +52,7 @@ M.on_confirm_done = function(opts)
         if evt.commit_character then
           return
         end
-
+        
         local entry = evt.entry
         local commit_character = entry:get_commit_characters()
         local bufnr = vim.api.nvim_get_current_buf()
@@ -84,59 +83,61 @@ M.on_confirm_done = function(opts)
     end
 end
 
-M.cpp_pairs = function(evt)
-    if not (vim.o.filetype == "c" or vim.o.filetype == "cpp") then
-        return
-    end
+M.cpp_pairs = function()
+    local cmp_config = require('cmp.config')
+    local cmp_comparetors = cmp_config.get().sorting.comparators
 
-    local c = vim.api.nvim_win_get_cursor(0)[2]
-    local line = vim.api.nvim_get_current_line()
-    if line:sub(c, c) ~= '>' then
-        return
-    end
-
-    local entry = evt.entry
-    local item = entry:get_completion_item()
-    local pairs = ''
-    local functionsig = item.label
-    if  (functionsig:sub(#functionsig, #functionsig) == '>' or
-            functionsig == ' template')
-    then
-        if functionsig:sub(2, 8) == 'include' then
-            pairs = ' '
+    local unpack = unpack or table.unpack
+    local function cpp_sort_cmp(entry1, entry2)
+        local kind1 = entry1.completion_item.kind
+        local kind2 = entry2.completion_item.kind
+        if vim.o.filetype ~= "cpp" then
+            return nil
         end
-        pairs = pairs .. '<>'
-        pairs = pairs .. utils.esc('<left>')
-        vim.api.nvim_feedkeys(pairs, "n", false)
+        if kind1 == Kind.Constructor and kind2 == Kind.Class then
+            return false
+        end
+        if kind1 == Kind.Class and kind2 == Kind.Constructor then
+            return true
+        end
+        return nil
+    end
+
+    cmp.setup({
+        sorting = {
+            comparators = {
+                cpp_sort_cmp,
+                unpack(cmp_comparetors),
+            }
+        }
+    })
+    return function(evt)
+        if not (vim.o.filetype == "c" or vim.o.filetype == "cpp") then
+            return
+        end
+
+        local c = vim.api.nvim_win_get_cursor(0)[2]
+        local line = vim.api.nvim_get_current_line()
+        if line:sub(c, c) == '>' then
+            return
+        end
+
+        local entry = evt.entry
+        local item = entry:get_completion_item()
+        local pairs = ''
+        local functionsig = item.label
+        if (functionsig:sub(#functionsig, #functionsig) == '>' or
+                functionsig == ' template')
+        then
+            if functionsig:sub(2, 8) == 'include' then
+                pairs = ' '
+            end
+            pairs = pairs .. '<>'
+            pairs = pairs .. utils.esc('<left>')
+            vim.api.nvim_feedkeys(pairs, "n", false)
+        end
     end
 end
 
-local cmp_config = require('cmp.config')
-local cmp_comparetors = cmp_config.get().sorting.comparators
-
-local unpack = unpack or table.unpack
-local function cpp_sort_cmp(entry1, entry2)
-   local kind1 = entry1.completion_item.kind
-   local kind2 = entry2.completion_item.kind
-   if vim.o.filetype ~= "cpp" then
-      return nil
-   end
-   if kind1 == Kind.Constructor and kind2 == Kind.Class then
-      return false
-   end
-   if kind1 == Kind.Class and kind2 == Kind.Constructor then
-      return true
-   end
-   return nil
-end
-
-cmp.setup({
-   sorting = {
-      comparators = {
-         cpp_sort_cmp,
-         unpack(cmp_comparetors),
-      }
-   }
-})
 
 return M

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -138,9 +138,9 @@ M.cpp_pairs = function()
             end
             pairs = pairs .. '<>'
             pairs = pairs .. utils.esc(utils.key.join_left)
-            OLD_lazyredraw = vim.o.lazyredraw
+            local old_lazyredraw = vim.o.lazyredraw
             vim.o.lazyredraw = true
-            vim.api.nvim_feedkeys(pairs .. utils.esc("<cmd>lua vim.o.lazyredraw = OLD_lazyredraw<cr>"),"i", false)
+            vim.api.nvim_feedkeys(pairs .. utils.esc("<cmd>lua vim.o.lazyredraw =" .. (old_lazyredraw and "true" or "false") .. "<cr>"),"i", false)
         end
     end
 end

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -137,8 +137,10 @@ M.cpp_pairs = function()
                 pairs = ' '
             end
             pairs = pairs .. '<>'
-            pairs = pairs .. utils.esc('<left>')
-            vim.api.nvim_feedkeys(pairs, "n", false)
+            pairs = pairs .. utils.esc(utils.key.join_left)
+            OLD_lazyredraw = vim.o.lazyredraw
+            vim.o.lazyredraw = true
+            vim.api.nvim_feedkeys(pairs .. utils.esc("<cmd>lua vim.o.lazyredraw = OLD_lazyredraw<cr>"),"i", false)
         end
     end
 end

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -1,6 +1,7 @@
 local autopairs = require('nvim-autopairs')
 local handlers = require('nvim-autopairs.completion.handlers')
 local cmp = require('cmp')
+local utils = require('nvim-autopairs.utils')
 
 local Kind = cmp.lsp.CompletionItemKind
 
@@ -105,14 +106,13 @@ M.cpp_pairs = function(evt)
             pairs = ' '
         end
         pairs = pairs .. '<>'
-        pairs = vim.api.nvim_replace_termcodes(pairs .. "<left>", true, false, true)
+        pairs = pairs .. utils.esc('<left>')
         vim.api.nvim_feedkeys(pairs, "n", false)
     end
 end
 
 local cmp_config = require('cmp.config')
 local cmp_comparetors = cmp_config.get().sorting.comparators
-local kind = cmp.lsp.CompletionItemKind
 
 local unpack = unpack or table.unpack
 local function cpp_sort_cmp(entry1, entry2)
@@ -121,10 +121,10 @@ local function cpp_sort_cmp(entry1, entry2)
    if vim.o.filetype ~= "cpp" then
       return nil
    end
-   if kind1 == kind.Constructor and kind2 == kind.Class then
+   if kind1 == Kind.Constructor and kind2 == Kind.Class then
       return false
    end
-   if kind1 == kind.Class and kind2 == kind.Constructor then
+   if kind1 == Kind.Class and kind2 == Kind.Constructor then
       return true
    end
    return nil

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -51,9 +51,9 @@ M.on_confirm_done = function(opts)
 
     return function(evt)
         if evt.commit_character then
-          return
+            return
         end
-        
+
         local entry = evt.entry
         local commit_character = entry:get_commit_characters()
         local bufnr = vim.api.nvim_get_current_buf()
@@ -62,11 +62,11 @@ M.on_confirm_done = function(opts)
 
         -- Without options and fallback
         if not opts.filetypes[filetype] and not opts.filetypes["*"] then
-          return
+            return
         end
 
         if opts.filetypes[filetype] == false then
-          return
+            return
         end
 
         -- If filetype is nil then use *
@@ -84,6 +84,7 @@ M.on_confirm_done = function(opts)
     end
 end
 
+local loaded_cpp_sort = false
 M.cpp_pairs = function()
     local cmp_config = require('cmp.config')
     local cmp_comparetors = cmp_config.get().sorting.comparators
@@ -103,15 +104,17 @@ M.cpp_pairs = function()
         end
         return nil
     end
-
-    cmp.setup({
-        sorting = {
-            comparators = {
-                cpp_sort_cmp,
-                unpack(cmp_comparetors),
+    if loaded_cpp_sort == false then
+        cmp.setup({
+            sorting = {
+                comparators = {
+                    cpp_sort_cmp,
+                    unpack(cmp_comparetors),
+                }
             }
-        }
-    })
+        })
+        loaded_cpp_sort = true
+    end
     return function(evt)
         if not (vim.o.filetype == "c" or vim.o.filetype == "cpp") then
             return

--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -104,7 +104,7 @@ M.cpp_pairs = function()
         end
         return nil
     end
-    if loaded_cpp_sort == false then
+    if loaded_cpp_sort == false and cmp_comparetors then
         cmp.setup({
             sorting = {
                 comparators = {


### PR DESCRIPTION
this issue #405 inspired me to make this pr
this pr adds `cpp_pairs` to the completion pairs
which does 
```
press < 
template|    -> template<|>
#include|    -> #include <|> // extra space for include
std::vector| -> std::vector<|>
```
`cpp_sort_cmp` is there to make sure templated classes are picked over constructors for templated classes
without this we wouldn't detect templated classes