### PR TITLE
fix Python handler erroring because of writing to a nil table

### DIFF
--- a/lua/nvim-autopairs/completion/handlers.lua
+++ b/lua/nvim-autopairs/completion/handlers.lua
@@ -82,7 +82,9 @@ M.lisp = function (char, item, bufnr, _, _)
 end
 
 M.python = function(char, item, bufnr, rules, _)
-   item.data.funcParensDisabled = false
+   if item.data then
+       item.data.funcParensDisabled = false
+   end
    M["*"](char,item,bufnr,rules)
 end
 


### PR DESCRIPTION
well i forgot to check if data is nil sorry about that
checking should fix this
https://github.com/windwp/nvim-autopairs/issues/410