### PR TITLE
Disable on_confirm_done for all TeX file types

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -45,6 +45,8 @@ M.filetypes = {
         }
     },
     tex = false,
+    plaintex = false,
+    context = false,
     haskell = false,
     purescript = false
 }


### PR DESCRIPTION
Since on_confirm_done is disabled for all LaTeX documents (file type 'tex'), it should also be disabled for all other TeX file types. Currently it is still enabled on TeX files (plaintex) and ConTeXt files (context).

This is a little bit irritating for new users, since when start writing a new LaTeX file with the extension '*.tex' it has the type plaintex in the beginning.

See https://neovim.io/doc/user/filetype.html#ft-tex-plugin