### PR TITLE
fix: don't add parentheses after bash/shell functions

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -48,7 +48,9 @@ M.filetypes = {
     plaintex = false,
     context = false,
     haskell = false,
-    purescript = false
+    purescript = false,
+    sh = false,
+    bash = false
 }
 
 M.on_confirm_done = function(opts)


### PR DESCRIPTION
Arguments are passed just by appending them after a space, parentheses not used.