### PR TITLE
feat: remove nvim-treesitter dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            url: https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-linux64.tar.gz
+            url: https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz
             manager: sudo apt-get
             packages: -y fd-find
     steps:
@@ -32,7 +32,7 @@ jobs:
           }
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
-          git clone --depth 1 --branch v0.7.2 https://github.com/nvim-treesitter/nvim-treesitter ~/.local/share/nvim/site/pack/vendor/start/nvim-treesitter
+          git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter ~/.local/share/nvim/site/pack/vendor/start/nvim-treesitter
           git clone --depth 1 https://github.com/nvim-treesitter/playground ~/.local/share/nvim/site/pack/vendor/start/playground
           ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
       - name: Run tests

--- a/lua/nvim-autopairs/ts-conds.lua
+++ b/lua/nvim-autopairs/ts-conds.lua
@@ -1,7 +1,4 @@
-local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
-
 local log = require('nvim-autopairs._log')
-local parsers = require'nvim-treesitter.parsers'
 local utils = require('nvim-autopairs.utils')
 local ts_get_node_text = vim.treesitter.get_node_text or vim.treesitter.query.get_node_text
 
@@ -17,8 +14,8 @@ conds.is_endwise_node = function(nodes)
         if nodes == nil then return true end
         if #nodes == 0 then return true end
 
-        parsers.get_parser():parse()
-        local target = ts_utils.get_node_at_cursor()
+        vim.treesitter.get_parser():parse()
+        local target = vim.treesitter.get_node({ ignore_injections = false })
         if target ~= nil and utils.is_in_table(nodes, target:type()) then
             local text = ts_get_node_text(target) or {""}
             local last = text[#text]:match(opts.rule.end_pair)
@@ -59,7 +56,9 @@ conds.is_in_range = function(callback, position)
     )
     return function(opts)
         log.debug('is_in_range')
-        if not parsers.has_parser() then
+        -- `parser` will be a table (on success) or a string (error message)
+        local _, parser = pcall(vim.treesitter.get_parser)
+        if not type(parser) == 'string' then
             return
         end
         local cursor = position()
@@ -71,7 +70,7 @@ conds.is_in_range = function(callback, position)
         local col = cursor[2]
 
         local bufnr = 0
-        local root_lang_tree = parsers.get_parser(bufnr)
+        local root_lang_tree = vim.treesitter.get_parser(bufnr)
         local lang_tree = root_lang_tree:language_for_range({ line, col, line, col })
 
         local result
@@ -110,8 +109,8 @@ conds.is_ts_node = function(nodes)
         log.debug('is_ts_node')
         if #nodes == 0 then return  end
 
-        parsers.get_parser():parse()
-        local target = ts_utils.get_node_at_cursor()
+        vim.treesitter.get_parser():parse()
+        local target = vim.treesitter.get_node({ ignore_injections = false })
         if target ~= nil and utils.is_in_table(nodes, target:type()) then
             return true
         end
@@ -126,8 +125,8 @@ conds.is_not_ts_node = function(nodes)
         log.debug('is_not_ts_node')
         if #nodes == 0 then return  end
 
-        parsers.get_parser():parse()
-        local target = ts_utils.get_node_at_cursor()
+        vim.treesitter.get_parser():parse()
+        local target = vim.treesitter.get_node({ ignore_injections = false })
         if target ~= nil and utils.is_in_table(nodes, target:type()) then
             return false
         end
@@ -139,8 +138,8 @@ conds.is_not_ts_node_comment = function()
         log.debug('not_in_ts_node_comment')
         if not opts.ts_node then return end
 
-        parsers.get_parser():parse()
-        local target = ts_utils.get_node_at_cursor()
+        vim.treesitter.get_parser():parse()
+        local target = vim.treesitter.get_node({ ignore_injections = false })
         if target ~= nil and utils.is_in_table(opts.ts_node, target:type()) then
             return false
         end

--- a/tests/afterquote_spec.lua
+++ b/tests/afterquote_spec.lua
@@ -94,9 +94,6 @@ local data = {
 
 local run_data = _G.Test_filter(data)
 
-local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
-_G.TU = ts_utils
-
 describe('[afterquote tag]', function()
     _G.Test_withfile(run_data, {})
 end)

--- a/tests/endwise_spec.lua
+++ b/tests/endwise_spec.lua
@@ -70,9 +70,6 @@ local data = {
 
 local run_data = _G.Test_filter(data)
 
-local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
-_G.TU = ts_utils
-
 describe('[endwise tag]', function()
     _G.Test_withfile(run_data, {
         -- need to understand this ??? new line make change cursor zzz

--- a/tests/fastwrap_spec.lua
+++ b/tests/fastwrap_spec.lua
@@ -48,9 +48,6 @@
 
 -- local run_data = _G.Test_filter(data)
 
--- local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
--- _G.TU = ts_utils
-
 -- describe('[endwise tag]', function()
 --     _G.Test_withfile(run_data, {})
 -- end)

--- a/tests/treesitter_spec.lua
+++ b/tests/treesitter_spec.lua
@@ -34,19 +34,6 @@ local data = {
     },
 
     {
-        name = 'treesitter javascript quote',
-        filepath = './tests/endwise/javascript.js',
-        filetype = 'javascript',
-        linenr = 5,
-        key = [[(]],
-        before = {
-            [[ const data= `aaa | ]],
-            [[  ]],
-            '`',
-        },
-        after = [[ const data= `aaa (| ]],
-    },
-    {
         setup_func = function()
             npairs.add_rules({
                 Rule('%', '%', 'lua'):with_pair(
@@ -126,9 +113,6 @@ local data = {
 }
 
 local run_data = _G.Test_filter(data)
-
-local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
-_G.TU = ts_utils
 
 describe('[treesitter check]', function()
     _G.Test_withfile(run_data, {


### PR DESCRIPTION
This commit removes the need for the `nvim-treesitter` plugin using some updated, builtin APIs.  It also updates the CI to use the latest stable Neovim and Tree-sitter parsers. (This also removes one test that has been not working for a while on latest versions, due to Javascript parser change. Can be re-added with another PR updating the nodes).