### PR TITLE
fix(nix): proper multi-line string rule

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -44,7 +44,7 @@ local function setup(opt)
         Rule("```.*$", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc" }):only_cr():use_regex(true),
         Rule('"""', '"""', { "python", "elixir", "julia", "kotlin" }):with_pair(cond.not_before_char('"', 3)),
         Rule("'''", "'''", { "python" }):with_pair(cond.not_before_char('"', 3)),
-        quote("'", "'", "-rust")
+        quote("'", "'", { "-rust", "-nix" })
             :with_pair(function(opts)
                 -- python literals string
                 local str = utils.text_sub_char(opts.line, opts.col - 1, 1)
@@ -54,6 +54,7 @@ local function setup(opt)
             end)
             :with_pair(cond.not_before_regex("%w")),
         quote("'", "'", "rust"):with_pair(cond.not_before_regex("[%w<&]")):with_pair(cond.not_after_text(">")),
+        Rule("''", "''", 'nix'):with_move(cond.after_text("'")),
         quote("`", "`"),
         quote('"', '"', "-vim"),
         quote('"', '"', "vim"):with_pair(cond.not_before_regex("^%s*$", -1)),


### PR DESCRIPTION
Adds a rule for `''` which is special in `nix` (there are also no regular single quote strings)