### PR TITLE
fix(nix): don't add parenthesis after functions

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -50,7 +50,8 @@ M.filetypes = {
     haskell = false,
     purescript = false,
     sh = false,
-    bash = false
+    bash = false,
+    nix = false
 }
 
 M.on_confirm_done = function(opts)


### PR DESCRIPTION
Nix is like Bash, functions are called just with spaces to separate arguments.