### PR TITLE
feat: add all key to ts_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ npairs.setup({
     ts_config = {
         lua = {'string'},-- it will not add a pair on that treesitter node
         javascript = {'template_string'},
+        all = {'comment'}, -- don't add pairs in comments of any language
         java = false,-- don't check treesitter on java
     }
 })

--- a/doc/nvim-autopairs.txt
+++ b/doc/nvim-autopairs.txt
@@ -310,6 +310,7 @@ You can use treesitter to check for a pair.
         ts_config = {
             lua = {'string'},-- it will not add a pair on that treesitter node
             javascript = {'template_string'},
+            all = {'comment'}, -- don't add pairs in comments of any language
             java = false,-- don't check treesitter on java
         }
     })

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -195,6 +195,17 @@ local function is_disable()
         M.set_buf_rule({}, 0)
         return true
     end
+
+    if M.config.check_ts and M.config.ts_config.all and #M.config .ts_config.all > 0 then
+        local cursor = api.nvim_win_get_cursor(0)
+        local ok, captures = pcall(vim.treesitter.get_captures_at_pos, 0, cursor[1] - 1, math.max(cursor[2] - 1, 0))
+        for _, capture in ipairs(ok and captures or {}) do
+            if vim.tbl_contains(M.config.ts_config.all, capture.capture) then
+                return true
+            end
+        end
+    end
+
     return false
 end
 


### PR DESCRIPTION
This PR adds a special key to `ts_config`, which allows disabling auto-pairing in all applicable Treesitter nodes in all languages.