### PR TITLE
fix(cmp): disable on_confirm_done for helm

### DIFF
--- a/lua/nvim-autopairs/completion/cmp.lua
+++ b/lua/nvim-autopairs/completion/cmp.lua
@@ -51,7 +51,8 @@ M.filetypes = {
     purescript = false,
     sh = false,
     bash = false,
-    nix = false
+    nix = false,
+    helm = false
 }
 
 M.on_confirm_done = function(opts)


### PR DESCRIPTION
One more language that does not use () on functions :)