### PR TITLE
fix(fast-wrap): restore leftcol when it begins to shift text

### DIFF
--- a/lua/nvim-autopairs/fastwrap.lua
+++ b/lua/nvim-autopairs/fastwrap.lua
@@ -189,6 +189,10 @@ M.highlight_wrap = function(tbl_pos, row, col, end_col, whitespace_line)
     if config.use_virt_lines then
         local virt_lines = {}
         local start = 0
+        local left_col = vim.fn.winsaveview().leftcol
+        if left_col > 0 then
+            vim.fn.winrestview({ leftcol = 0 })
+        end
         for _, pos in ipairs(tbl_pos) do
             virt_lines[#virt_lines + 1] = { whitespace_line:sub(start + 1, pos.pos - 1), 'Normal' }
             virt_lines[#virt_lines + 1] = { pos.key, config.highlight }


### PR DESCRIPTION
When window view is shifted, fast wrap virtlines is also shifted, result in inconsistent state. The easiest solution is to restore window col view to 0.


https://github.com/user-attachments/assets/0aab36b6-c33c-4bf1-9089-3833bfad792e

