### PR TITLE
feat(fast_wrap): add options for direct end_key use

### DIFF
--- a/doc/nvim-autopairs.txt
+++ b/doc/nvim-autopairs.txt
@@ -412,6 +412,8 @@ FASTWRAP ~
           chars = { '{', '[', '(', '"', "'" },
           pattern = [=[[%'%"%>%]%)%}%,]]=],
           end_key = '$',
+	  end_is_end = true, -- use end_key directly (no follow up)
+	  avoid_move_to_end = true, -- stay for direct end_key use
           keys = 'qwertyuiopzxcvbnmasdfghjkl',
           check_comma = true,
           highlight = 'Search',

--- a/doc/nvim-autopairs.txt
+++ b/doc/nvim-autopairs.txt
@@ -412,7 +412,7 @@ FASTWRAP ~
           chars = { '{', '[', '(', '"', "'" },
           pattern = [=[[%'%"%>%]%)%}%,]]=],
           end_key = '$',
-	  avoid_move_to_end = true, -- stay for direct end_key use
+          avoid_move_to_end = true, -- stay for direct end_key use
           keys = 'qwertyuiopzxcvbnmasdfghjkl',
           check_comma = true,
           highlight = 'Search',

--- a/doc/nvim-autopairs.txt
+++ b/doc/nvim-autopairs.txt
@@ -412,7 +412,6 @@ FASTWRAP ~
           chars = { '{', '[', '(', '"', "'" },
           pattern = [=[[%'%"%>%]%)%}%,]]=],
           end_key = '$',
-	  end_is_end = true, -- use end_key directly (no follow up)
 	  avoid_move_to_end = true, -- stay for direct end_key use
           keys = 'qwertyuiopzxcvbnmasdfghjkl',
           check_comma = true,

--- a/lua/nvim-autopairs/fastwrap.lua
+++ b/lua/nvim-autopairs/fastwrap.lua
@@ -8,7 +8,6 @@ local default_config = {
     chars = { '{', '[', '(', '"', "'" },
     pattern = [=[[%'%"%>%]%)%}%,%`]]=],
     end_key = '$',
-    end_is_end = true, -- always treat end_key as eol
     avoid_move_to_end = true, -- choose your move behaviour for non-alphabetical end_keys' 
     before_key = 'h',
     after_key = 'l',
@@ -119,14 +118,12 @@ M.show = function(line)
         M.highlight_wrap(list_pos, row, col, #line, whitespace_line)
         vim.defer_fn(function()
             -- get the first char
-            --TODO: add logic to detect if two characters are necessary or just one
             local char = #list_pos == 1 and config.end_key or M.getchar_handler()
             vim.api.nvim_buf_clear_namespace(0, M.ns_fast_wrap, row, row + 1)
 
-            -- FIXME: add logic to avoid duplicate key locations
             for _, pos in pairs(list_pos) do
                 -- handle end_key specially
-                if char == config.end_key and char == pos.key and config.end_is_end then
+                if char == config.end_key and char == pos.key then
                     vim.print("Run to end!")
                     -- M.highlight_wrap({pos = pos.pos, key = config.end_key}, row, col, #line, whitespace_line)
                     local move_end_key = (not config.avoid_move_to_end and char == string.upper(config.end_key))

--- a/lua/nvim-autopairs/fastwrap.lua
+++ b/lua/nvim-autopairs/fastwrap.lua
@@ -8,6 +8,8 @@ local default_config = {
     chars = { '{', '[', '(', '"', "'" },
     pattern = [=[[%'%"%>%]%)%}%,%`]]=],
     end_key = '$',
+    end_is_end = true, -- always treat end_key as eol
+    avoid_move_to_end = true, -- choose your move behaviour for non-alphabetical end_keys' 
     before_key = 'h',
     after_key = 'l',
     cursor_pos_before = true,
@@ -57,7 +59,7 @@ M.show = function(line)
         if end_pair == '' then
             return
         end
-        local list_pos = {}
+        local list_pos = {} --holds target locations
         local index = 1
         local str_length = #line
         local offset = -1
@@ -90,6 +92,7 @@ M.show = function(line)
                 )
             end
         end
+        log.debug(list_pos)
 
         local end_col, end_pos
         if config.manual_position then
@@ -116,9 +119,20 @@ M.show = function(line)
         M.highlight_wrap(list_pos, row, col, #line, whitespace_line)
         vim.defer_fn(function()
             -- get the first char
+            --TODO: add logic to detect if two characters are necessary or just one
             local char = #list_pos == 1 and config.end_key or M.getchar_handler()
             vim.api.nvim_buf_clear_namespace(0, M.ns_fast_wrap, row, row + 1)
+
+            -- FIXME: add logic to avoid duplicate key locations
             for _, pos in pairs(list_pos) do
+                -- handle end_key specially
+                if char == config.end_key and char == pos.key and config.end_is_end then
+                    vim.print("Run to end!")
+                    -- M.highlight_wrap({pos = pos.pos, key = config.end_key}, row, col, #line, whitespace_line)
+                    local move_end_key = (not config.avoid_move_to_end and char == string.upper(config.end_key))
+                    M.move_bracket(line, pos.col+1, end_pair, move_end_key)
+                    break
+                end
                 local hl_mark = {
                     { pos = pos.pos - 1, key = config.before_key },
                     { pos = pos.pos + 1, key = config.after_key },


### PR DESCRIPTION
Barely tested
I have no idea how to develop neovim / lua etc, so take it as you will.
 
Next step would be removing repeating options

```
e.g.        (|abc)))))))
currently:       qwerty$
better:          h     $
```

