### PR TITLE
♻️refactor(vim.highlight): Deprecation

### DIFF
--- a/lua/nvim-autopairs/fastwrap.lua
+++ b/lua/nvim-autopairs/fastwrap.lua
@@ -215,7 +215,15 @@ M.highlight_wrap = function(tbl_pos, row, col, end_col, whitespace_line)
         })
     else
         if config.highlight_grey then
-            vim.highlight.range(
+            -- TODO: Deleteme after nvim 0.11 is released.
+            local hl
+            vim.fn.has("nvim-0.11") == 1 then
+                hl = vim.hl
+            else
+                hl = vim.highlight
+            end
+    
+            hl.range(
                 bufnr,
                 M.ns_fast_wrap,
                 config.highlight_grey,

--- a/lua/nvim-autopairs/fastwrap.lua
+++ b/lua/nvim-autopairs/fastwrap.lua
@@ -215,15 +215,7 @@ M.highlight_wrap = function(tbl_pos, row, col, end_col, whitespace_line)
         })
     else
         if config.highlight_grey then
-            -- TODO: Deleteme after nvim 0.11 is released.
-            local hl
-            vim.fn.has("nvim-0.11") == 1 then
-                hl = vim.hl
-            else
-                hl = vim.highlight
-            end
-    
-            hl.range(
+            (vim.hl or vim.highlight).range(
                 bufnr,
                 M.ns_fast_wrap,
                 config.highlight_grey,


### PR DESCRIPTION
vim.highlight is deprecated starting `nvim 0.11`.