### PR TITLE
Add suport of eruby filetype in basic tag rule

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -69,6 +69,7 @@ local function setup(opt)
                 "html",
                 "htmlangular",
                 "htmldjango",
+                "eruby",
                 "php",
                 "blade",
                 "typescript",


### PR DESCRIPTION
This requests adds support basic rules for eruby filetype which used in Ruby on Rails `erb`  html template files.