### PR TITLE
feat: add quarto filetype to triple backticks rules

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -41,9 +41,9 @@ local function setup(opt)
     local bracket = bracket_creator(opt)
     local rules = {
         Rule("<!--", "-->", { "html", "markdown" }):with_cr(cond.none()),
-        Rule("```", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc" })
+        Rule("```", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc", "quarto" })
             :with_pair(cond.not_before_char('`', 3)),
-        Rule("```.*$", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc" }):only_cr():use_regex(true),
+        Rule("```.*$", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc", "quarto" }):only_cr():use_regex(true),
         Rule('"""', '"""', { "python", "elixir", "julia", "kotlin", "scala","sbt" }):with_pair(cond.not_before_char('"', 3)),
         Rule("'''", "'''", { "python" }):with_pair(cond.not_before_char("'", 3)),
         quote("'", "'", { "-rust", "-nix" })


### PR DESCRIPTION
Add quarto to the filetypes supported for the triple backticks rules. Quaro is basically an extension to markdown and related to both pandoc and rmarkdown.