### PR TITLE
feat: add an `enabled` configuration function for more control of buffer attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ use {
 
 ``` lua
 {
+    enabled = function(bufnr) return true end, -- control if auto-pairs should be enabled when attaching to a buffer
     disable_filetype = { "TelescopePrompt", "spectre_panel" },
     disable_in_macro = true, -- disable when recording or executing a macro
     disable_in_visualblock = false, -- disable when insert after visual block mode

--- a/doc/nvim-autopairs.txt
+++ b/doc/nvim-autopairs.txt
@@ -59,6 +59,7 @@ DEFAULT VALUES                                 *nvim-autopairs-default-values*
 
 >
     {
+        enabled = function(bufnr) return true end, -- control if auto-pairs should be enabled when attaching to a buffer
         disable_filetype = { "TelescopePrompt", "spectre_panel" }
         disable_in_macro = true  -- disable when recording or executing a macro
         disable_in_visualblock = false -- disable when insert after visual block mode

--- a/lua/nvim-autopairs.lua
+++ b/lua/nvim-autopairs.lua
@@ -16,6 +16,7 @@ local default = {
     map_c_h = false,
     map_c_w = false,
     map_cr = true,
+    enabled = nil,
     disable_filetype = { 'TelescopePrompt', 'spectre_panel' },
     disable_in_macro = true,
     disable_in_visualblock = false,
@@ -194,7 +195,10 @@ local function is_disable()
         return true
     end
 
-    if utils.check_filetype(M.config.disable_filetype, vim.bo.filetype) then
+    if
+        utils.check_filetype(M.config.disable_filetype, vim.bo.filetype)
+        or (M.config.enabled and not M.config.enabled(api.nvim_get_current_buf()))
+    then
         del_keymaps()
         M.set_buf_rule({}, 0)
         return true


### PR DESCRIPTION
This adds a new configuration option called `enabled` that gives the user more control over when a buffer should be enabled for autopairs. This can be useful for enabling/disabling based on more than just filetype such as buffer type