### PR TITLE
Match keyword when it's at the start of the line

### DIFF
--- a/lua/nvim-autopairs/rules/endwise-ruby.lua
+++ b/lua/nvim-autopairs/rules/endwise-ruby.lua
@@ -12,6 +12,11 @@ local rules = {
     endwise('[%s=]%scase%s.+$',   'end', 'ruby', nil),
     endwise('[%s=]%swhile%s.+$',  'end', 'ruby', nil),
     endwise('[%s=]%suntil%s.+$',  'end', 'ruby', nil),
+    endwise('^if%s.+$',           'end', 'ruby', nil),
+    endwise('^unless%s.+$',       'end', 'ruby', nil),
+    endwise('^case%s.+$',         'end', 'ruby', nil),
+    endwise('^while%s.+$',        'end', 'ruby', nil),
+    endwise('^until%s.+$',        'end', 'ruby', nil),
 }
 
 return rules


### PR DESCRIPTION
Previously on my PR #79, these 3 scenarios are working:

```ruby
# "if" is not at the start of a line -> end is added
class SomeClass
  if flag
  end 
...

# "if" is right after an equal sign -> end is added
tmp = if flag
      end

# "if" is not after an equal sign -> end is not ended
return "ok" if flag
```

However, I couldn't handle the case when some of the keywords are at the beginning of a line. Now this PR should do the trick:
```ruby
# "if" is at the start of a line -> end is added
if flag
end
```