### PR TITLE
Add Elixir's heex filetype to the list of basic rule filetypes.

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -67,6 +67,7 @@ local function setup(opt)
             ">[%w%s]*$",
             "^%s*</",
             {
+                "heex",
                 "html",
                 "htmlangular",
                 "htmldjango",


### PR DESCRIPTION
HEEx is short for "HTML + Embedded Elixir", the embedded templates used by Elixir's Phoenix framework. You commonly mix HTML alongside Elixir syntax (in parenthesis):

`<h1>{expand_title(@title)}</h1>`

This PR ensures basic autopairs functionality in those files for the HTML tags.