### PR TITLE
feat: add gitcommit ft to triple backtick rules

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -41,7 +41,7 @@ local function setup(opt)
     local bracket = bracket_creator(opt)
     local rules = {
         Rule("<!--", "-->", { "html", "markdown" }):with_cr(cond.none()),
-        Rule("```", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc", "quarto", "typst" })
+        Rule("```", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc", "quarto", "typst", "gitcommit" })
             :with_pair(cond.not_before_char('`', 3)),
         Rule("```.*$", "```", { "markdown", "vimwiki", "rmarkdown", "rmd", "pandoc", "quarto", "typst" }):only_cr():use_regex(true),
         Rule('"""', '"""', { "python", "elixir", "julia", "kotlin", "scala","sbt" }):with_pair(cond.not_before_char('"', 3)),


### PR DESCRIPTION
I often use triple backticks for code snippets in commit messages.

This PR applies the existing triple backtick rule to the `gitcommit` file type.