### PR TITLE
feat: insert pair " in bash command substitution and variable expansion

### DIFF
--- a/lua/nvim-autopairs/rules/basic.lua
+++ b/lua/nvim-autopairs/rules/basic.lua
@@ -58,7 +58,15 @@ local function setup(opt)
         quote("'", "'", "rust"):with_pair(cond.not_before_regex("[%w<&]")):with_pair(cond.not_after_text(">")),
         Rule("''", "''", 'nix'):with_move(cond.after_text("'")),
         quote("`", "`"),
-        quote('"', '"', "-vim"),
+        quote('"', '"', { "-vim", "-bash", "-sh" }),
+        quote('"', '"', { "bash", "sh" }):with_pair(function(opts)
+            -- add a constraint for quote check if input " in bash command 
+            -- substitution "$()", variable expansion "${}".
+            local str = utils.get_shell_substitution_content_before_pos(opts.text, opts.col - 1)
+            if str then
+                return not utils.is_in_quotes(str, #str, '"')
+            end
+        end, 1),
         quote('"', '"', "vim"):with_pair(cond.not_before_regex("^%s*$", -1)),
         bracket("(", ")"),
         bracket("[", "]"),

--- a/lua/nvim-autopairs/utils.lua
+++ b/lua/nvim-autopairs/utils.lua
@@ -199,4 +199,31 @@ M.get_prev_char = function(opt)
     return opt.line:sub(opt.col - 1, opt.col + #opt.rule.start_pair - 2)
 end
 
+--- Get inner content of nearest bash substitution or variable expansion
+--- before cursor position
+--- eg:
+---     command substitution $(ab|c) -> ab
+---     variable expansion ${ab|c|} -> ab
+--- @param line string input line
+--- @param pos integer cursor pos (1-based)
+--- @return string | nil
+M.get_shell_substitution_content_before_pos = function(line, pos)
+    local i = pos
+    local char, prev2
+
+    while i > 1 do
+        char = line:sub(i, i)
+        if char == ')' or char == '}' then
+            return nil
+        end
+
+        prev2 = line:sub(i - 1, i)
+        if prev2 == '$(' or prev2 == '${' then
+            return line:sub(i + 1, pos)
+        end
+
+        i = i - 1
+    end
+end
+
 return M

--- a/tests/nvim-autopairs_spec.lua
+++ b/tests/nvim-autopairs_spec.lua
@@ -845,6 +845,144 @@ local data = {
             "|```python"
         }
     },
+    {
+        name   = [[add " in a bash-like command substitution, but not in a bash file]],
+        key    = [["]],
+        before = [["$(|)"]],
+        after  = [["$("|)"]],
+    },
+    {
+        name   = [[add " in a bash-like variable expansion, but not in a bash file]],
+        key    = [["]],
+        before = [["${|}"]],
+        after  = [["${"|}"]],
+    },
+    {
+        name   = [[add " in a bash command substitution]],
+        key    = [["]],
+        before = [["$(|)"]],
+        after  = [["$("|")"]],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " in a bash command substitution, after a pair "]],
+        key    = [["]],
+        before = [["$("$cmd" |)"]],
+        after  = [["$("$cmd" "|")"]],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " in a bash command substitution, after a open "]],
+        key    = [["]],
+        before = [["$("|)"]],
+        after  = [["$(""|)"]],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " after a bash command substitution]],
+        key    = [["]],
+        before = [["$("$var")" | ]],
+        after  = [["$("$var")" "|"]],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " in a variable command substitution]],
+        key    = [["]],
+        before = [["${|}"]],
+        after  = [["${"|"}"]],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " in a bash variable expansion, after a pair "]],
+        key    = [["]],
+        before = [["${"$cmd" |}"]],
+        after  = [["${"$cmd" "|"}"]],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " in a bash variable expansion, after a open "]],
+        key    = [["]],
+        before = [["${"|}"]],
+        after  = [["${""|}"]],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " in a bash variable expansion, within array.]],
+        key    = [["]],
+        before = [==["${arr[|]}"]==],
+        after  = [==["${arr["|"]}"]==],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " after a bash variable expansion]],
+        key    = [["]],
+        before = [["${"$var"}" | ]],
+        after  = [["${"$var"}" "|"]],
+        filetype = "bash"
+    },
+    {
+        name   = [[add " in a bash command substitution]],
+        key    = [["]],
+        before = [["$(|)"]],
+        after  = [["$("|")"]],
+        filetype = "sh"
+    },
+    {
+        name   = [[add " in a bash command substitution, after a pair "]],
+        key    = [["]],
+        before = [["$("$cmd" |)"]],
+        after  = [["$("$cmd" "|")"]],
+        filetype = "sh"
+    },
+    {
+        name   = [[add " in a bash command substitution, after a open "]],
+        key    = [["]],
+        before = [["$("|)"]],
+        after  = [["$(""|)"]],
+        filetype = "sh"
+    },
+    {
+        name   = [[add " after a bash command substitution]],
+        key    = [["]],
+        before = [["$("$var")" | ]],
+        after  = [["$("$var")" "|"]],
+        filetype = "sh"
+    },
+    {
+        name   = [[add " in a variable command substitution]],
+        key    = [["]],
+        before = [["${|}"]],
+        after  = [["${"|"}"]],
+        filetype = "sh"
+    },
+    {
+        name   = [[add " in a bash variable expansion, after a pair "]],
+        key    = [["]],
+        before = [["${"$cmd" |}"]],
+        after  = [["${"$cmd" "|"}"]],
+        filetype = "sh"
+    },
+    {
+        name   = [[add " in a bash variable expansion, after a open "]],
+        key    = [["]],
+        before = [["${"|}"]],
+        after  = [["${""|}"]],
+        filetype = "sh"
+    },
+    {
+        name   = [[add " after a bash variable expansion]],
+        key    = [["]],
+        before = [["${"$var"}" | ]],
+        after  = [["${"$var"}" "|"]],
+        filetype = "sh"
+    },
+    {
+        name   = [[add " in a bash variable expansion, within array.]],
+        key    = [["]],
+        before = [==["${arr[|]}"]==],
+        after  = [==["${arr["|"]}"]==],
+        filetype = "sh"
+    },
 }
 
 local run_data = _G.Test_filter(data)


### PR DESCRIPTION
`$()` is bash command substitution.

When input char `"` in a command substitution, check for paired `""` quotes will fail.

original behavior:

```
Before        Input         After
------------------------------------
"$(|)"        "             "$("|)"
"$("|)"       "             "$(""|")"
```

Wrapping a `$()` command substitution with `""` will interfere `"` quote detection.

now behavior:

```
Before        Input         After
------------------------------------
"$(|)"        "             "$("|")"
"$("|)"       "             "$(""|)"
```